### PR TITLE
Resolve ZAP testing CSP header errors using nonce on views

### DIFF
--- a/DFC.Composite.Shell.Models/Common/Constants.cs
+++ b/DFC.Composite.Shell.Models/Common/Constants.cs
@@ -9,5 +9,6 @@
         public const string NationalCareersToolkit = "nationalcareers_toolkit";
         public const string ApplicationInsightsScriptResourceAddress = "ApplicationInsights:ScriptResourceAddress";
         public const string ApplicationInsightsConnectSources = "ApplicationInsights:ConnectSources";
+        public const string ApplicationInsightsInstrumentationKey = "ApplicationInsights:InstrumentationKey";
     }
 }

--- a/DFC.Composite.Shell.Views.UnitTests/DFC.Composite.Shell.Views.UnitTests.csproj
+++ b/DFC.Composite.Shell.Views.UnitTests/DFC.Composite.Shell.Views.UnitTests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="RazorEngine.NetCore" Version="2.2.2" />

--- a/DFC.Composite.Shell.Views.UnitTests/Services.ViewRenderer/HtmlSupportTemplateBase.cs
+++ b/DFC.Composite.Shell.Views.UnitTests/Services.ViewRenderer/HtmlSupportTemplateBase.cs
@@ -1,4 +1,6 @@
-﻿using RazorEngine.Templating;
+﻿using FakeItEasy;
+using Microsoft.AspNetCore.Mvc;
+using RazorEngine.Templating;
 
 namespace DFC.Composite.Shell.Views.Test.Services.ViewRenderer
 {
@@ -7,13 +9,14 @@ namespace DFC.Composite.Shell.Views.Test.Services.ViewRenderer
         public HtmlSupportTemplateBase()
         {
             Html = new RazorHtmlHelper();
+            Component = A.Fake<IViewComponentHelper>();
         }
 
         public RazorHtmlHelper Html { get; set; }
+        public IViewComponentHelper Component { get; set; }
 
         public void IgnoreSection(string sectionName)
         {
-
         }
     }
 }

--- a/DFC.Composite.Shell.Views.UnitTests/Tests/AppInsightsViewComponentTests.cs
+++ b/DFC.Composite.Shell.Views.UnitTests/Tests/AppInsightsViewComponentTests.cs
@@ -1,0 +1,35 @@
+﻿using DFC.Composite.Shell.Models.Common;
+using DFC.Composite.Shell.ViewComponents;
+using DFC.Composite.Shell.Views.Test.Extensions;
+using FakeItEasy;
+using Microsoft.Extensions.Configuration;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DFC.Composite.Shell.Views.Test.Tests
+{
+    public class AppInsightsViewComponentTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("someKey")]
+        public async Task ReturnsAppInsightsKeyWhenItExists(string expectedInsightsKey)
+        {
+            // Arrange
+            var configuration = A.Fake<IConfiguration>();
+            var configSection = A.Fake<IConfigurationSection>();
+            configSection.Value = expectedInsightsKey;
+
+            A.CallTo(() => configuration.GetSection(Constants.ApplicationInsightsInstrumentationKey)).Returns(configSection);
+            var viewComponent = new AppInsightsViewComponent(configuration);
+
+            // Act
+            var result = await viewComponent.InvokeAsync();
+
+            // Assert
+            var viewComponentModel = result.ViewDataModelAs<AppInsightsViewModel>();
+            Assert.Equal(expectedInsightsKey, viewComponentModel.InstrumentationKey);
+        }
+    }
+}

--- a/DFC.Composite.Shell/DFC.Composite.Shell.csproj
+++ b/DFC.Composite.Shell/DFC.Composite.Shell.csproj
@@ -8,11 +8,12 @@
     <ApplicationInsightsAnnotationResourceId>/subscriptions/962cae10-2950-412a-93e3-d8ae92b17896/resourcegroups/dfc-dev-compui-shell-rg/providers/microsoft.insights/components/dfc-dev-compui-shell-ai</ApplicationInsightsAnnotationResourceId>
     <CodeAnalysisRuleSet>../DFC.Digital.CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  
+ 
   <ItemGroup>
     <PackageReference Include="CorrelationId" Version="2.1.0" />
     <PackageReference Include="DFC.Common.Standard" Version="0.1.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.4" />
+    <PackageReference Include="Joonasw.AspNetCore.SecurityHeaders" Version="3.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.7.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
@@ -23,6 +24,8 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.4" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="3.0.0" />
+    <PackageReference Include="NWebsec.AspNetCore.Mvc" Version="3.0.0" />
+    <PackageReference Include="NWebsec.AspNetCore.Mvc.TagHelpers" Version="3.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.Composite.Shell/Startup.cs
+++ b/DFC.Composite.Shell/Startup.cs
@@ -79,12 +79,24 @@ namespace DFC.Composite.Shell
 
             // Configure security headers
             app.UseCsp(options => options
-            .DefaultSources(s => s.Self())
-            .ScriptSources(s => s.Self().UnsafeInline().CustomSources(new string[] { "www.google-analytics.com", "www.googletagmanager.com", $"{cdnLocation}/{Constants.NationalCareersToolkit}/js/", $"{Configuration.GetValue<string>(Constants.ApplicationInsightsScriptResourceAddress)}" }))
-            .StyleSources(s => s.Self().UnsafeInline().CustomSources($"{cdnLocation}/{Constants.NationalCareersToolkit}/css/"))
-            .FontSources(s => s.Self().CustomSources($"{cdnLocation}/{Constants.NationalCareersToolkit}/fonts/"))
-            .ImageSources(s => s.Self().CustomSources(new string[] { $"{cdnLocation}/{Constants.NationalCareersToolkit}/images/", "www.google-analytics.com", "*.doubleclick.net" }))
-            .ConnectSources(s => s.Self().CustomSources($"{Configuration.GetValue<string>(Constants.ApplicationInsightsConnectSources)}")));
+                .DefaultSources(s => s.Self())
+                .ScriptSources(s => s
+                    .StrictDynamic()
+                    .Self()
+                    .UnsafeEval()
+                    .CustomSources("https://az416426.vo.msecnd.net/scripts/", "www.google-analytics.com", "www.googletagmanager.com", $"{cdnLocation}/{Constants.NationalCareersToolkit}/js/", $"{Configuration.GetValue<string>(Constants.ApplicationInsightsScriptResourceAddress)}"))
+                .StyleSources(s => s
+                    .Self()
+                    .CustomSources($"{cdnLocation}/{Constants.NationalCareersToolkit}/css/"))
+                .FontSources(s => s
+                    .Self()
+                    .CustomSources($"{cdnLocation}/{Constants.NationalCareersToolkit}/fonts/"))
+                .ImageSources(s => s
+                    .Self()
+                    .CustomSources($"{cdnLocation}/{Constants.NationalCareersToolkit}/images/", "www.google-analytics.com", "*.doubleclick.net"))
+                .ConnectSources(s => s
+                    .Self()
+                    .CustomSources($"{Configuration.GetValue<string>(Constants.ApplicationInsightsConnectSources)}", "https://dc.services.visualstudio.com/")));
 
             app.UseXfo(options => options.SameOrigin());
             app.UseXXssProtection(options => options.EnabledWithBlockMode());
@@ -188,7 +200,6 @@ namespace DFC.Composite.Shell
                 endpoints.MapControllerRoute("Robots", "Robots.txt", new { controller = "Robot", action = "Robot" });
 
                 endpoints.MapControllerRoute("Application.GetOrPost", "{path}/{**data}", new { controller = "Application", action = "Action" });
-
             });
         }
     }

--- a/DFC.Composite.Shell/ViewComponents/AppInsightsViewComponent.cs
+++ b/DFC.Composite.Shell/ViewComponents/AppInsightsViewComponent.cs
@@ -1,0 +1,25 @@
+﻿using DFC.Composite.Shell.Models.Common;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using System.Threading.Tasks;
+
+namespace DFC.Composite.Shell.ViewComponents
+{
+    public class AppInsightsViewComponent : ViewComponent
+    {
+        private readonly IConfiguration configuration;
+
+        public AppInsightsViewComponent(IConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
+
+        public async Task<IViewComponentResult> InvokeAsync()
+        {
+            var appInsightsKey = configuration.GetValue<string>(Constants.ApplicationInsightsInstrumentationKey);
+
+            var vm = new AppInsightsViewModel { InstrumentationKey = appInsightsKey };
+            return await Task.FromResult(View(vm)).ConfigureAwait(true);
+        }
+    }
+}

--- a/DFC.Composite.Shell/ViewComponents/AppInsightsViewModel.cs
+++ b/DFC.Composite.Shell/ViewComponents/AppInsightsViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace DFC.Composite.Shell.ViewComponents
+{
+    public class AppInsightsViewModel
+    {
+        public string InstrumentationKey { get; set; }
+    }
+}

--- a/DFC.Composite.Shell/Views/Shared/Components/AppInsights/Default.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/Components/AppInsights/Default.cshtml
@@ -1,0 +1,12 @@
+﻿@model DFC.Composite.Shell.ViewComponents.AppInsightsViewModel
+
+<script type="text/javascript" nws-csp-add-nonce="true">
+
+    var appInsights = window.appInsights || function (a) {
+        function b(a) { c[a] = function () { var b = arguments; c.queue.push(function () { c[a].apply(c, b) }) } } var c = { config: a }, d = document, e = window; setTimeout(function () { var b = d.createElement("script"); b.src = a.url || "https://az416426.vo.msecnd.net/scripts/a/ai.0.js", d.getElementsByTagName("script")[0].parentNode.appendChild(b) }); try { c.cookie = d.cookie } catch (a) { } c.queue = []; for (var f = ["Event", "Exception", "Metric", "PageView", "Trace", "Dependency"]; f.length;)b("track" + f.pop()); if (b("setAuthenticatedUserContext"), b("clearAuthenticatedUserContext"), b("startTrackEvent"), b("stopTrackEvent"), b("startTrackPage"), b("stopTrackPage"), b("flush"), !a.disableExceptionTracking) { f = "onerror", b("_" + f); var g = e[f]; e[f] = function (a, b, d, e, h) { var i = g && g(a, b, d, e, h); return !0 !== i && c["_" + f](a, b, d, e, h), i } } return c
+    }({
+        instrumentationKey: '@Model.InstrumentationKey'
+    });
+
+    window.appInsights = appInsights, appInsights.queue && 0 === appInsights.queue.length && appInsights.trackPageView();
+</script>

--- a/DFC.Composite.Shell/Views/Shared/_ApplicationInsightsJavascript.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_ApplicationInsightsJavascript.cshtml
@@ -1,2 +1,0 @@
-﻿@inject Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet JavaScriptSnippet
-@Html.Raw(JavaScriptSnippet.FullScript)

--- a/DFC.Composite.Shell/Views/Shared/_ErrorSummary.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_ErrorSummary.cshtml
@@ -2,7 +2,7 @@
 {
     ViewBag.Title = "Error: " + @ViewBag.Title;
 
-    <script type="text/javascript">
+    <script type="text/javascript" nws-csp-add-nonce="true">
         document.title = '@ViewBag.Title';
     </script>
 

--- a/DFC.Composite.Shell/Views/Shared/_GoogleTagManagerScripts.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_GoogleTagManagerScripts.cshtml
@@ -1,10 +1,10 @@
 ﻿<!-- Page-hiding snippet (recommended)  -->
-<style>
+<style nws-csp-add-nonce="true">
     .async-hide {
         opacity: 0 !important
     }
 </style>
-<script>
+<script nws-csp-add-nonce="true">
     (function (a, s, y, n, c, h, i, d, e) {
         s.className += ' ' + y; h.start = 1 * new Date;
         h.end = i = function () { s.className = s.className.replace(RegExp(' ?' + y), '') };
@@ -13,7 +13,7 @@
         { 'GTM-554PPX9': true });
 </script> 
 <!-- Google Tag Manager -->
-<script>
+<script nws-csp-add-nonce="true">
     (function (w, d, s, l, i) {
         w[l] = w[l] || []; w[l].push({
             'gtm.start':

--- a/DFC.Composite.Shell/Views/Shared/_JQueryInitialise.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_JQueryInitialise.cshtml
@@ -9,9 +9,9 @@
     string VersionedPathForDfcDigitalMinJs = ViewData["VersionedPathForDfcDigitalMinJs"].ToString();
 }
 
-<script src="@(VersionedPathForJQueryBundleMinJs)" type="text/javascript"></script>
-<script src="@(VersionedPathForAllMinJs)" type="text/javascript"></script>
+<script src="@(VersionedPathForJQueryBundleMinJs)" type="text/javascript" nws-csp-add-nonce="true"></script>
+<script src="@(VersionedPathForAllMinJs)" type="text/javascript" nws-csp-add-nonce="true"></script>
 
-<script>window.GOVUKFrontend.initAll()</script>
+<script nws-csp-add-nonce="true">window.GOVUKFrontend.initAll()</script>
 
-<script src="@(VersionedPathForDfcDigitalMinJs)"></script>
+<script src="@(VersionedPathForDfcDigitalMinJs)" nws-csp-add-nonce="true"></script>

--- a/DFC.Composite.Shell/Views/Shared/_LayoutFullWidth.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_LayoutFullWidth.cshtml
@@ -9,7 +9,7 @@
         @RenderSection("Head", required: false)
     }
 
-    <partial name="_ApplicationInsightsJavascript" />
+    @await Component.InvokeAsync("AppInsights", null)
 </head>
 
 <body class="govuk-template__body ">
@@ -20,7 +20,6 @@
         <partial name="_PhaseBanner" />
 
         <partial name="_ErrorSummary" />
-
     </div>
 
     @if (IsSectionDefined("BodyTop"))
@@ -62,14 +61,12 @@
                     IgnoreSection("SideBarRight");
                 }
             }
-
         </main>
 
         @if (IsSectionDefined("BodyFooter"))
         {
             @RenderSection("BodyFooter", required: false)
         }
-
     </div>
 
     <partial name="_GovUkFooter" />

--- a/DFC.Composite.Shell/Views/Shared/_LayoutSidebarLeft.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_LayoutSidebarLeft.cshtml
@@ -10,7 +10,7 @@
         @RenderSection("Head", required: false)
     }
 
-    <partial name="_ApplicationInsightsJavascript" />
+    @await Component.InvokeAsync("AppInsights", null)
 </head>
 
 <body class="govuk-template__body ">
@@ -21,7 +21,6 @@
         <partial name="_PhaseBanner" />
 
         <partial name="_ErrorSummary" />
-
     </div>
 
     @if (IsSectionDefined("BodyTop"))
@@ -70,18 +69,15 @@
                     IgnoreSection("SideBarRight");
                 }
             }
-
         </main>
 
         @if (IsSectionDefined("BodyFooter"))
         {
             @RenderSection("BodyFooter", required: false)
         }
-
     </div>
 
     <partial name="_GovUkFooter" />
-
 
     <partial name="_JQueryInitialise" />
 

--- a/DFC.Composite.Shell/Views/Shared/_LayoutSidebarRight.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_LayoutSidebarRight.cshtml
@@ -9,7 +9,7 @@
         @RenderSection("Head", required: false)
     }
 
-    <partial name="_ApplicationInsightsJavascript" />
+    @await Component.InvokeAsync("AppInsights", null)
 </head>
 
 <body class="govuk-template__body ">
@@ -68,14 +68,12 @@
                     IgnoreSection("SideBarLeft");
                 }
             }
-
         </main>
 
         @if (IsSectionDefined("BodyFooter"))
         {
             @RenderSection("BodyFooter", required: false)
         }
-
     </div>
 
     <partial name="_GovUkFooter" />

--- a/DFC.Composite.Shell/Views/Shared/_jsEnabled.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_jsEnabled.cshtml
@@ -1,3 +1,3 @@
-﻿<script>
+﻿<script nws-csp-add-nonce="true">
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>

--- a/DFC.Composite.Shell/Views/_ViewImports.cshtml
+++ b/DFC.Composite.Shell/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 ﻿@using DFC.Composite.Shell
 @using DFC.Composite.Shell.Models
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, NWebsec.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
Removing unsafe-inline from the CSP headers caused existing inline scripts (and styles) to throw errors in the browser. Adding the nonce to the views in conjunction with the existing NWebSec package resolved these issues