### PR TITLE
Release v1.1.37.1 

### DIFF
--- a/DFC.Composite.Shell.IntegrationTests/DFC.Composite.Shell.IntegrationTests.csproj
+++ b/DFC.Composite.Shell.IntegrationTests/DFC.Composite.Shell.IntegrationTests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="appsettings-template.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="appsettings-template.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
@@ -21,7 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/DFC.Composite.Shell.IntegrationTests/Services/TestPathService.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Services/TestPathService.cs
@@ -24,6 +24,16 @@ namespace DFC.Composite.Shell.Integration.Test.Services
 
             paths.Add(new PathModel
             {
+                Path = "path4",
+                DocumentId = Guid.NewGuid(),
+                IsOnline = true,
+                Layout = PageLayout.FullWidthNoMain,
+                TopNavigationOrder = 1,
+                TopNavigationText = "Path4",
+            });
+
+            paths.Add(new PathModel
+            {
                 Path = "path2",
                 DocumentId = Guid.NewGuid(),
                 IsOnline = true,

--- a/DFC.Composite.Shell.Models/Enums.cs
+++ b/DFC.Composite.Shell.Models/Enums.cs
@@ -6,6 +6,7 @@
         FullWidth = 1,
         SidebarRight = 2,
         SidebarLeft = 3,
+        FullWidthNoMain = 4
     }
 
     public enum PageRegion

--- a/DFC.Composite.Shell.Models/PageViewModel.cs
+++ b/DFC.Composite.Shell.Models/PageViewModel.cs
@@ -22,6 +22,8 @@ namespace DFC.Composite.Shell.Models
 
         public string VersionedPathForDfcDigitalMinJs { get; set; }
 
+        public string VersionedPathForCompUiMinJs { get; set; }
+
         public string Path { get; set; }
 
         public string LayoutName { get; set; } = "_LayoutFullWidth";

--- a/DFC.Composite.Shell.Services/Application/ApplicationService.cs
+++ b/DFC.Composite.Shell.Services/Application/ApplicationService.cs
@@ -51,12 +51,8 @@ namespace DFC.Composite.Shell.Services.Application
 
             if (application.Path.IsOnline)
             {
-                //Get the markup at the head url first. This will create the session if it doesn't already exist
-                var applicationHeadRegionOutput = await GetApplicationHeadRegionMarkUpAsync(application, application.Regions.First(x => x.PageRegion == PageRegion.Head), article, queryString).ConfigureAwait(false);
-                pageModel.PageRegionContentModels.First(x => x.PageRegionType == PageRegion.Head).Content = new HtmlString(applicationHeadRegionOutput);
-
                 //Load related regions
-                var otherRegionsTask = LoadRelatedRegions(application, pageModel, article);
+                var otherRegionsTask = LoadRelatedRegions(application, pageModel, article, queryString);
 
                 //Wait until everything is done
                 await Task.WhenAll(otherRegionsTask).ConfigureAwait(false);
@@ -88,7 +84,7 @@ namespace DFC.Composite.Shell.Services.Application
                 var applicationBodyRegionTask = GetPostMarkUpAsync(application, article, formParameters);
 
                 //Load related regions
-                var otherRegionsTask = LoadRelatedRegions(application, pageModel, string.Empty);
+                var otherRegionsTask = LoadRelatedRegions(application, pageModel, article, string.Empty);
 
                 //Wait until everything is done
                 await Task.WhenAll(applicationBodyRegionTask, otherRegionsTask).ConfigureAwait(false);
@@ -178,7 +174,7 @@ namespace DFC.Composite.Shell.Services.Application
         {
             var url = FormatArticleUrl(regionModel.RegionEndpoint, article, queryString);
 
-            var result = await this.contentRetriever.GetContent(url, regionModel, false, RequestBaseUrl).ConfigureAwait(false);
+            var result = await contentRetriever.GetContent(url, regionModel, false, RequestBaseUrl).ConfigureAwait(false);
 
             return contentProcessorService.Process(result, RequestBaseUrl, application.RootUrl);
         }
@@ -193,22 +189,25 @@ namespace DFC.Composite.Shell.Services.Application
                 return Task.FromResult(string.Empty);
             }
 
-            var uri = new Uri(bodyRegion.RegionEndpoint);
-            var url = $"{uri.Scheme}://{uri.Authority}/{application.Path.Path}/{article}";
+            var url = FormatArticleUrl(bodyRegion.RegionEndpoint, article, string.Empty);
 
             return contentRetriever.PostContent(url, bodyRegion, formParameters, RequestBaseUrl);
         }
 
-        private async Task LoadRelatedRegions(ApplicationModel application, PageViewModel pageModel, string article)
+        private async Task LoadRelatedRegions(ApplicationModel application, PageViewModel pageModel, string article, string queryString)
         {
+            //Get the markup at the head url first. This will create the session if it doesn't already exist
+            var applicationHeadRegionOutput = await GetApplicationHeadRegionMarkUpAsync(application, application.Regions.First(x => x.PageRegion == PageRegion.Head), article, queryString).ConfigureAwait(false);
+            pageModel.PageRegionContentModels.First(x => x.PageRegionType == PageRegion.Head).Content = new HtmlString(applicationHeadRegionOutput);
+
             var tasks = new List<Task<string>>();
 
-            var heroBannerRegionTask = GetMarkup(tasks, PageRegion.HeroBanner, application.Regions, article);
-            var breadcrumbRegionTask = GetMarkup(tasks, PageRegion.Breadcrumb, application.Regions, article);
-            var bodyTopRegionTask = GetMarkup(tasks, PageRegion.BodyTop, application.Regions, article);
-            var sidebarLeftRegionTask = GetMarkup(tasks, PageRegion.SidebarLeft, application.Regions, article);
-            var sidebarRightRegionTask = GetMarkup(tasks, PageRegion.SidebarRight, application.Regions, article);
-            var bodyFooterRegionTask = GetMarkup(tasks, PageRegion.BodyFooter, application.Regions, article);
+            var heroBannerRegionTask = GetMarkup(tasks, PageRegion.HeroBanner, application.Regions, article, queryString);
+            var breadcrumbRegionTask = GetMarkup(tasks, PageRegion.Breadcrumb, application.Regions, article, queryString);
+            var bodyTopRegionTask = GetMarkup(tasks, PageRegion.BodyTop, application.Regions, article, queryString);
+            var sidebarLeftRegionTask = GetMarkup(tasks, PageRegion.SidebarLeft, application.Regions, article, queryString);
+            var sidebarRightRegionTask = GetMarkup(tasks, PageRegion.SidebarRight, application.Regions, article, queryString);
+            var bodyFooterRegionTask = GetMarkup(tasks, PageRegion.BodyFooter, application.Regions, article, queryString);
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
 
@@ -220,7 +219,7 @@ namespace DFC.Composite.Shell.Services.Application
             PopulatePageRegionContent(application, pageModel, PageRegion.BodyFooter, bodyFooterRegionTask);
         }
 
-        private Task<string> GetMarkup(List<Task<string>> tasks, PageRegion regionType, IEnumerable<RegionModel> regions, string article)
+        private Task<string> GetMarkup(List<Task<string>> tasks, PageRegion regionType, IEnumerable<RegionModel> regions, string article, string queryString)
         {
             var pageRegionModel = regions.FirstOrDefault(x => x.PageRegion == regionType);
 
@@ -234,7 +233,7 @@ namespace DFC.Composite.Shell.Services.Application
                 return Task.FromResult(pageRegionModel.OfflineHTML);
             }
 
-            var url = FormatArticleUrl(pageRegionModel.RegionEndpoint, article, string.Empty);
+            var url = FormatArticleUrl(pageRegionModel.RegionEndpoint, article, queryString);
 
             var task = contentRetriever.GetContent(url, pageRegionModel, true, RequestBaseUrl);
 

--- a/DFC.Composite.Shell.Services/ApplicationSitemap/ApplicationSitemapService.cs
+++ b/DFC.Composite.Shell.Services/ApplicationSitemap/ApplicationSitemapService.cs
@@ -48,6 +48,11 @@ namespace DFC.Composite.Shell.Services.ApplicationSitemap
 
                 var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
+                if (string.IsNullOrWhiteSpace(responseString))
+                {
+                    return default;
+                }
+
                 var serializer = new XmlSerializer(typeof(T));
                 using (var reader = new StringReader(responseString))
                 {

--- a/DFC.Composite.Shell.Services/Auth/AzureB2CAuthClient.cs
+++ b/DFC.Composite.Shell.Services/Auth/AzureB2CAuthClient.cs
@@ -1,0 +1,113 @@
+﻿using DFC.Composite.Shell.Services.Auth.Models;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DFC.Composite.Shell.Services.Auth
+{
+    public class AzureB2CAuthClient : IOpenIdConnectClient
+    {
+        private readonly OpenIDConnectSettings settings;
+        private readonly IConfigurationManager<OpenIdConnectConfiguration> configurationManager;
+        private readonly SecurityTokenHandler tokenHandler;
+
+        public AzureB2CAuthClient(IOptions<OpenIDConnectSettings> settings, SecurityTokenHandler securityTokenHandler, IConfigurationManager<OpenIdConnectConfiguration> configurationManager)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            this.settings = settings.Value;
+            this.configurationManager = configurationManager;
+            tokenHandler = securityTokenHandler;
+        }
+
+        public async Task<string> GetRegisterUrl()
+        {
+            var configDoc = await configurationManager.GetConfigurationAsync(CancellationToken.None).ConfigureAwait(false);
+            var queryParams = new Dictionary<string, string>();
+            queryParams.Add("p", "B2C_1A_account_signup");
+            queryParams.Add("client_id", settings.ClientId);
+            queryParams.Add("nonce", "defaultNonce");
+            queryParams.Add("redirect_uri", settings.RedirectUrl);
+            queryParams.Add("scope", "openid");
+            queryParams.Add("response_type", "id_token");
+            queryParams.Add("prompt", "login");
+            string registerUrl = QueryHelpers.AddQueryString(GetUrlWithoutParams(configDoc.AuthorizationEndpoint), queryParams);
+
+            return registerUrl;
+        }
+
+        public async Task<string> GetSignInUrl()
+        {
+            var configDoc = await configurationManager.GetConfigurationAsync(CancellationToken.None).ConfigureAwait(false);
+            var queryParams = new Dictionary<string, string>();
+            queryParams.Add("p", "B2C_1A_signin_invitation");
+            queryParams.Add("client_id", settings.ClientId);
+            queryParams.Add("nonce", "defaultNonce");
+            queryParams.Add("redirect_uri", settings.RedirectUrl);
+            queryParams.Add("scope", "openid");
+            queryParams.Add("response_type", "id_token");
+            queryParams.Add("response_mode", "query");
+            queryParams.Add("prompt", "login");
+            string registerUrl = QueryHelpers.AddQueryString(GetUrlWithoutParams(configDoc.AuthorizationEndpoint), queryParams);
+
+            return registerUrl;
+        }
+
+        public async Task<string> GetSignOutUrl(string redirectUrl)
+        {
+            var configDoc = await configurationManager.GetConfigurationAsync(CancellationToken.None).ConfigureAwait(false);
+            var queryParams = new Dictionary<string, string>();
+            queryParams.Add("client_id", settings.ClientId);
+            queryParams.Add("post_logout_redirect_uri", string.IsNullOrEmpty(redirectUrl) ? settings.SignOutRedirectUrl : redirectUrl);
+            string registerUrl = QueryHelpers.AddQueryString(configDoc.EndSessionEndpoint, queryParams);
+
+            return registerUrl;
+        }
+
+        public async Task<JwtSecurityToken> ValidateToken(string token)
+        {
+            var configDoc = await configurationManager.GetConfigurationAsync(CancellationToken.None).ConfigureAwait(false);
+            return ValidateToken(token, configDoc);
+        }
+
+        private static string GetUrlWithoutParams(string url)
+        {
+            return new UriBuilder(url) { Query = string.Empty }.ToString();
+        }
+
+        private JwtSecurityToken ValidateToken(
+            string token,
+            OpenIdConnectConfiguration discoveryDocument,
+            CancellationToken ct = default(CancellationToken))
+        {
+            var signingKeys = discoveryDocument.SigningKeys;
+
+            var validationParameters = new TokenValidationParameters
+            {
+                RequireExpirationTime = true,
+                RequireSignedTokens = true,
+                ValidateIssuer = true,
+                ValidIssuer = discoveryDocument.Issuer,
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKeys = signingKeys,
+                ValidateLifetime = true,
+                ValidateAudience = false,
+                ClockSkew = TimeSpan.FromMinutes(2),
+            };
+
+            tokenHandler.ValidateToken(token, validationParameters, out var rawValidatedToken);
+
+            return (JwtSecurityToken)rawValidatedToken;
+        }
+    }
+}

--- a/DFC.Composite.Shell.Services/Auth/IOpenIdconnectClient.cs
+++ b/DFC.Composite.Shell.Services/Auth/IOpenIdconnectClient.cs
@@ -1,0 +1,16 @@
+﻿using System.IdentityModel.Tokens.Jwt;
+using System.Threading.Tasks;
+
+namespace DFC.Composite.Shell.Services.Auth
+{
+    public interface IOpenIdConnectClient
+    {
+        Task<string> GetRegisterUrl();
+
+        Task<string> GetSignInUrl();
+
+        Task<JwtSecurityToken> ValidateToken(string token);
+
+        Task<string> GetSignOutUrl(string redirectUrl);
+    }
+}

--- a/DFC.Composite.Shell.Services/Auth/Models/AuthSettings.cs
+++ b/DFC.Composite.Shell.Services/Auth/Models/AuthSettings.cs
@@ -1,0 +1,13 @@
+﻿namespace DFC.Composite.Shell.Services.Auth.Models
+{
+    public class AuthSettings
+    {
+        public string Issuer { get; set; }
+
+        public string Audience { get; set; }
+
+        public string ClientSecret { get; set; }
+
+        public string DefaultRedirectUrl { get; set; }
+    }
+}

--- a/DFC.Composite.Shell.Services/Auth/Models/OpenIDConnectSettings.cs
+++ b/DFC.Composite.Shell.Services/Auth/Models/OpenIDConnectSettings.cs
@@ -1,0 +1,31 @@
+﻿namespace DFC.Composite.Shell.Services.Auth.Models
+{
+    public class OpenIDConnectSettings
+    {
+        public string OIDCConfigMetaDataUrl { get; set; }
+
+        public bool UseOIDCConfigDiscovery { get; set; }
+
+        public string ClientId { get; set; }
+
+        public string AuthorizeUrl { get; set; }
+
+        public string JWKsUrl { get; set; }
+
+        public string JWK { get; set; }
+
+        public string Issuer { get; set; }
+
+        public string RedirectUrl { get; set; }
+
+        public string AuthdUrl { get; set; }
+
+        public bool LogPersonalInfo { get; set; }
+
+        public string EndSessionUrl { get; set; }
+
+        public string SignOutRedirectUrl { get; set; }
+
+        public string Exponent { get; set; }
+    }
+}

--- a/DFC.Composite.Shell.Services/Auth/Models/OpenIdConnectConfig.cs
+++ b/DFC.Composite.Shell.Services/Auth/Models/OpenIdConnectConfig.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace DFC.Composite.Shell.Services.Auth.Models
+{
+    public class OpenIdConnectConfig
+    {
+        [JsonProperty("issuer")]
+        public string Issuer { get; set; }
+
+        [JsonProperty("authorization_endpoint")]
+        public string AuthorizationEndpoint { get; set; }
+
+        [JsonProperty("token_endpoint")]
+        public string TokenEndpoint { get; set; }
+
+        [JsonProperty("end_session_endpoint")]
+        public string EndSessionEndpoint { get; set; }
+
+        [JsonProperty("jwks_uri")]
+        public string JwksUri { get; set; }
+    }
+}

--- a/DFC.Composite.Shell.Services/ContentRetrieval/ContentRetriever.cs
+++ b/DFC.Composite.Shell.Services/ContentRetrieval/ContentRetriever.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 namespace DFC.Composite.Shell.Services.ContentRetrieval

--- a/DFC.Composite.Shell.Services/DFC.Composite.Shell.Services.csproj
+++ b/DFC.Composite.Shell.Services/DFC.Composite.Shell.Services.csproj
@@ -12,16 +12,20 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="3.1.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.6.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.6.0" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.2.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DFC.Composite.Shell.Services/Regions/RegionService.cs
+++ b/DFC.Composite.Shell.Services/Regions/RegionService.cs
@@ -1,4 +1,5 @@
 ﻿using DFC.Composite.Shell.Models;
+using Microsoft.AspNetCore.JsonPatch;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -32,7 +33,7 @@ namespace DFC.Composite.Shell.Services.Regions
         public async Task<bool> SetRegionHealthState(string path, PageRegion pageRegion, bool isHealthy)
         {
             var regionsUrl = $"{httpClient.BaseAddress}api/paths/{path}/regions/{(int)pageRegion}";
-            var regionPatchModel = new RegionPatchModel { IsHealthy = isHealthy };
+            var regionPatchModel = new JsonPatchDocument<RegionModel>().Add(x => x.IsHealthy, isHealthy);
             var jsonRequest = JsonConvert.SerializeObject(regionPatchModel);
 
             using (var content = new StringContent(jsonRequest, Encoding.UTF8, MediaTypeNames.Application.Json))

--- a/DFC.Composite.Shell.Services/Utilities/IVersionedFiles.cs
+++ b/DFC.Composite.Shell.Services/Utilities/IVersionedFiles.cs
@@ -13,5 +13,7 @@
         string VersionedPathForMainMinCss { get; }
 
         string VersionedPathForDfcDigitalMinJs { get; }
+
+        string VersionedPathForCompUiMinJs { get; }
     }
 }

--- a/DFC.Composite.Shell.Services/Utilities/VersionedFiles.cs
+++ b/DFC.Composite.Shell.Services/Utilities/VersionedFiles.cs
@@ -18,6 +18,7 @@ namespace DFC.Composite.Shell.Utilities
             VersionedPathForJQueryBundleMinJs = assetLocationAndVersionService?.GetCdnAssetFileAndVersion($"{brandingAssetsFolder}/js/jquerybundle.min.js");
             VersionedPathForAllMinJs = assetLocationAndVersionService?.GetCdnAssetFileAndVersion($"{brandingAssetsFolder}/js/all.min.js");
             VersionedPathForDfcDigitalMinJs = assetLocationAndVersionService?.GetCdnAssetFileAndVersion($"{brandingAssetsFolder}/js/dfcdigital.min.js");
+            VersionedPathForCompUiMinJs = assetLocationAndVersionService?.GetCdnAssetFileAndVersion($"{brandingAssetsFolder}/js/compui.min.js");
         }
 
         public string VersionedPathForMainMinCss { get; }
@@ -31,5 +32,7 @@ namespace DFC.Composite.Shell.Utilities
         public string VersionedPathForAllMinJs { get; }
 
         public string VersionedPathForDfcDigitalMinJs { get; }
+
+        public string VersionedPathForCompUiMinJs { get; }
     }
 }

--- a/DFC.Composite.Shell.UnitTests/ClientHandlers/MockHttpSession.cs
+++ b/DFC.Composite.Shell.UnitTests/ClientHandlers/MockHttpSession.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DFC.Composite.Shell.UnitTests.ClientHandlers
+{
+    public class MockHttpSession : ISession
+    {
+        readonly Dictionary<string, object> _sessionStorage = new Dictionary<string, object>();
+        string ISession.Id => throw new NotImplementedException();
+        bool ISession.IsAvailable => throw new NotImplementedException();
+        IEnumerable<string> ISession.Keys => _sessionStorage.Keys;
+        void ISession.Clear()
+        {
+            _sessionStorage.Clear();
+        }
+        Task ISession.CommitAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+        Task ISession.LoadAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+        void ISession.Remove(string key)
+        {
+            _sessionStorage.Remove(key);
+        }
+        void ISession.Set(string key, byte[] value)
+        {
+            _sessionStorage[key] = Encoding.UTF8.GetString(value);
+        }
+        bool ISession.TryGetValue(string key, out byte[] value)
+        {
+            if (_sessionStorage.Any(x=>x.Key == key))
+            {
+                value = Encoding.ASCII.GetBytes(_sessionStorage[key].ToString());
+                return true;
+            }
+            value = null;
+            return false;
+        }
+    }
+}

--- a/DFC.Composite.Shell.UnitTests/Controllers/AuthcontrollerTests.cs
+++ b/DFC.Composite.Shell.UnitTests/Controllers/AuthcontrollerTests.cs
@@ -1,0 +1,229 @@
+﻿using DFC.Composite.Shell.Controllers;
+using DFC.Composite.Shell.Services.Auth;
+using DFC.Composite.Shell.Services.Auth.Models;
+using DFC.Composite.Shell.UnitTests.ClientHandlers;
+using FakeItEasy;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DFC.Composite.Shell.UnitTests.Controllers
+{
+    public class AuthControllerTests
+    {
+        private readonly IOpenIdConnectClient authClient;
+        private readonly ILogger<AuthController> log;
+        private readonly DefaultHttpContext defaultContext;
+        private readonly IOptions<AuthSettings> defaultsettings;
+        private readonly IAuthenticationService defaultAuthService;
+
+        public AuthControllerTests()
+        {
+            authClient = A.Fake<IOpenIdConnectClient>();
+            log = A.Fake<ILogger<AuthController>>();
+            var requestServices = A.Fake<IServiceProvider>();
+            defaultAuthService = A.Fake<IAuthenticationService>();
+            A.CallTo(() => defaultAuthService.SignInAsync(A<HttpContext>.Ignored, A<string>.Ignored,
+                A<ClaimsPrincipal>.Ignored, A<AuthenticationProperties>.Ignored)).Returns(Task.CompletedTask);
+
+            A.CallTo(() => requestServices.GetService(typeof(IAuthenticationService))).Returns(defaultAuthService);
+
+            defaultContext = new DefaultHttpContext
+            {
+                RequestServices = requestServices,
+                Session = new MockHttpSession()
+            };
+
+            defaultsettings = Options.Create(new AuthSettings
+            {
+                Audience = "audience",
+                ClientSecret = "clientSecret123456",
+                Issuer = "issuer",
+                DefaultRedirectUrl = "test",
+            });
+        }
+
+        [Fact]
+        public async Task WhenSignInCalledWithOutRedirectUrlThenRedirectToLoginWithDefaultUrl()
+        {
+            A.CallTo(() => authClient.GetSignInUrl()).Returns("test");
+            var settings = Options.Create(new AuthSettings());
+            var controller = new AuthController(authClient, log, settings);
+
+            var result = await controller.SignIn(string.Empty).ConfigureAwait(false) as RedirectResult;
+
+            A.CallTo(() => authClient.GetSignInUrl()).MustHaveHappened();
+            Assert.Equal("test", result.Url);
+            controller.Dispose();
+        }
+
+        [Fact]
+        public async Task WhenSignOutCalledWithOutRedirectUrlThenRedirectToLoginWithDefaultUrl()
+        {
+            A.CallTo(() => authClient.GetSignOutUrl(string.Empty)).Returns("test");
+            var settings = Options.Create(new AuthSettings());
+            var controller = new AuthController(authClient, log, settings);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = defaultContext,
+            };
+            var result = await controller.SignOut(string.Empty).ConfigureAwait(false) as RedirectResult;
+
+            A.CallTo(() => authClient.GetSignOutUrl(string.Empty)).MustHaveHappened();
+            Assert.Equal("test", result.Url);
+        }
+
+        [Fact]
+        public async Task WhenRegisterCalledWithOutRedirectUrlThenRedirectToLoginWithDefaultUrl()
+        {
+            A.CallTo(() => authClient.GetRegisterUrl()).Returns("test");
+            var settings = Options.Create(new AuthSettings());
+            var controller = new AuthController(authClient, log, settings);
+
+            var result = await controller.Register(string.Empty).ConfigureAwait(false) as RedirectResult;
+
+            A.CallTo(() => authClient.GetRegisterUrl()).MustHaveHappened();
+            Assert.Equal("test", result.Url);
+            controller.Dispose();
+        }
+
+        [Fact]
+        public async Task WhenAuthCalledThenTokenIsValidated()
+        {
+            var token = "token";
+            var claims = new List<Claim>
+            {
+                new Claim("customerId", "customerId"),
+                new Claim("email", "email"),
+                new Claim("given_name", "given_name"),
+                new Claim("family_name", "family_name"),
+            new Claim("exp", DateTimeOffset.Now.AddHours(2).ToUnixTimeSeconds().ToString()),
+            };
+            A.CallTo(() => authClient.ValidateToken(token)).Returns(new JwtSecurityToken("test", "test", claims));
+            
+            var controller = new AuthController(authClient, log, defaultsettings);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = defaultContext,
+            };
+          
+            await controller.Auth(token).ConfigureAwait(false);
+
+            A.CallTo(() => authClient.ValidateToken(token)).MustHaveHappened();
+        }
+
+        [Fact]
+        public async Task WhenAuthCalledAndTokenIsInvalidThenThrowError()
+        {
+            var token = "token";
+            A.CallTo(() => authClient.ValidateToken(token)).Throws(new Exception());
+
+            var controller = new AuthController(authClient, log, defaultsettings);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = defaultContext,
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () => await controller.Auth(token).ConfigureAwait(false)).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task WhenAuthCalledThenCookieIsCreated()
+        {
+            var token = "token";
+            var claims = new List<Claim>
+            {
+                new Claim("customerId", "customerId"),
+                new Claim("email", "email"),
+                new Claim("given_name", "given_name"),
+                new Claim("family_name", "family_name"),
+                new Claim("exp", DateTimeOffset.Now.AddHours(2).ToUnixTimeSeconds().ToString()),
+            };
+            A.CallTo(() => authClient.ValidateToken(token)).Returns(new JwtSecurityToken("test", "test", claims));
+
+            var controller = new AuthController(authClient, log, defaultsettings);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = defaultContext,
+            };
+
+            await controller.Auth(token).ConfigureAwait(false);
+
+            A.CallTo(() => defaultAuthService.SignInAsync(A<HttpContext>.Ignored, A<string>.Ignored, A<ClaimsPrincipal>.Ignored, A<AuthenticationProperties>.Ignored)).MustHaveHappened();
+        }
+
+        [Fact]
+        public async Task WhenSignOutCalledThenCookieIsRemoved()
+        {
+            A.CallTo(() => authClient.GetSignOutUrl(string.Empty)).Returns("test");
+            var controller = new AuthController(authClient, log, defaultsettings);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = defaultContext,
+            };
+
+            await controller.SignOut(string.Empty).ConfigureAwait(false);
+
+            A.CallTo(() => defaultAuthService.SignOutAsync(A<HttpContext>.Ignored, A<string>.Ignored, A<AuthenticationProperties>.Ignored)).MustHaveHappened();
+        }
+
+        [Fact]
+        public async Task WhenAuthCalledThenRedirectToSessionUrl()
+        {
+            var token = "token";
+            var claims = new List<Claim>
+            {
+                new Claim("customerId", "customerId"),
+                new Claim("email", "email"),
+                new Claim("given_name", "given_name"),
+                new Claim("family_name", "family_name"),
+                new Claim("exp", DateTimeOffset.Now.AddHours(2).ToUnixTimeSeconds().ToString()),
+            };
+            A.CallTo(() => authClient.ValidateToken(token)).Returns(new JwtSecurityToken("test", "test", claims));
+
+            var controller = new AuthController(authClient, log, defaultsettings);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = defaultContext,
+            };
+            defaultContext.HttpContext.Session.SetString(AuthController.RedirectSessionKey, AuthController.RedirectSessionKey);
+
+            var result = await controller.Auth(token).ConfigureAwait(false) as RedirectResult;
+
+            Assert.Equal(result.Url, AuthController.RedirectSessionKey);
+        }
+
+        [Fact]
+        public async Task WhenAuthCalledAndSessionRedirectNotFoundThenRedirectToDefaultUrl()
+        {
+            var token = "token";
+            var claims = new List<Claim>
+            {
+                new Claim("customerId", "customerId"),
+                new Claim("email", "email"),
+                new Claim("given_name", "given_name"),
+                new Claim("family_name", "family_name"),
+                new Claim("exp", DateTimeOffset.Now.AddHours(2).ToUnixTimeSeconds().ToString()),
+            };
+            A.CallTo(() => authClient.ValidateToken(token)).Returns(new JwtSecurityToken("test", "test", claims));
+
+            var controller = new AuthController(authClient, log, defaultsettings);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = defaultContext,
+            };
+
+            var result = await controller.Auth(token).ConfigureAwait(false) as RedirectResult;
+
+            Assert.Equal(result.Url, defaultsettings.Value.DefaultRedirectUrl);
+        }
+    }
+}

--- a/DFC.Composite.Shell.UnitTests/DFC.Composite.Shell.UnitTests.csproj
+++ b/DFC.Composite.Shell.UnitTests/DFC.Composite.Shell.UnitTests.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/DFC.Composite.Shell.UnitTests/ServicesTests/ApplicationServiceTests.cs
+++ b/DFC.Composite.Shell.UnitTests/ServicesTests/ApplicationServiceTests.cs
@@ -187,12 +187,15 @@ namespace DFC.Composite.Shell.Test.ServicesTests
         public async Task PostMarkupAsyncForOnlineApplication()
         {
             // Arrange
-            var footerAndBodyRegions = new List<RegionModel> { defaultBodyRegion, defaultBodyFooterRegion };
+            var footerAndBodyRegions = new List<RegionModel> { defaultHeadRegion, defaultBodyRegion, defaultBodyFooterRegion };
             var fakeApplicationModel = new ApplicationModel { Path = defaultPathModel, Regions = footerAndBodyRegions };
             var pageModel = new PageViewModel();
             mapper.Map(fakeApplicationModel, pageModel);
 
-            A.CallTo(() => contentRetriever.PostContent($"{RequestBaseUrl}/{fakeApplicationModel.Path.Path}/{Article}", defaultBodyRegion, defaultFormPostParams, RequestBaseUrl)).Returns(BodyRegionContent);
+            var body = fakeApplicationModel.Regions.FirstOrDefault(x => x.PageRegion == PageRegion.Body);
+
+            A.CallTo(() => contentRetriever.PostContent($"{defaultBodyRegion.RegionEndpoint}/{Article}", defaultBodyRegion, defaultFormPostParams, RequestBaseUrl)).Returns(BodyRegionContent);
+            A.CallTo(() => contentRetriever.GetContent($"{defaultBodyFooterRegion.RegionEndpoint}/{Article}", defaultBodyFooterRegion, A<bool>.Ignored, RequestBaseUrl)).Returns(BodyFooterRegionContent);
 
             // Act
             await applicationService.PostMarkupAsync(fakeApplicationModel, "index", Article, defaultFormPostParams, pageModel).ConfigureAwait(false);
@@ -202,23 +205,23 @@ namespace DFC.Composite.Shell.Test.ServicesTests
             Assert.Equal(BodyRegionContent, pageModel.PageRegionContentModels.First(x => x.PageRegionType == PageRegion.Body).Content.Value);
             Assert.Equal(BodyFooterRegionContent, pageModel.PageRegionContentModels.First(x => x.PageRegionType == PageRegion.BodyFooter).Content.Value);
 
-            A.CallTo(() => contentRetriever.PostContent($"{RequestBaseUrl}/{fakeApplicationModel.Path.Path}/{Article}", defaultBodyRegion, defaultFormPostParams, RequestBaseUrl)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => contentRetriever.GetContent($"{defaultBodyFooterRegion.RegionEndpoint}", defaultBodyFooterRegion, A<bool>.Ignored, RequestBaseUrl)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => contentRetriever.PostContent($"{defaultBodyRegion.RegionEndpoint}/{Article}", defaultBodyRegion, defaultFormPostParams, RequestBaseUrl)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => contentRetriever.GetContent($"{defaultBodyFooterRegion.RegionEndpoint}/{Article}", defaultBodyFooterRegion, A<bool>.Ignored, RequestBaseUrl)).MustHaveHappenedOnceExactly();
         }
-
+        
         [Fact]
         public async Task PostMarkupAsyncForOnlineApplicationWhenBodyRegionEndpointIsEmptyThenContentNotPosted()
         {
             // Arrange
             var fakeBodyRegionEndpoint = string.Empty;
-
             var fakeBodyRegion = new RegionModel { PageRegion = PageRegion.Body, RegionEndpoint = fakeBodyRegionEndpoint, IsHealthy = true };
-            var fakeRegions = new List<RegionModel> { fakeBodyRegion, defaultBodyFooterRegion };
+            var fakeRegions = new List<RegionModel> { defaultHeadRegion, fakeBodyRegion, defaultBodyFooterRegion };
             var fakeApplicationModel = new ApplicationModel { Path = defaultPathModel, Regions = fakeRegions };
             var pageModel = new PageViewModel();
             mapper.Map(fakeApplicationModel, pageModel);
 
             A.CallTo(() => contentRetriever.PostContent($"{RequestBaseUrl}/{fakeApplicationModel.Path.Path}/{Article}", fakeBodyRegion, defaultFormPostParams, RequestBaseUrl)).Returns(BodyRegionContent);
+            A.CallTo(() => contentRetriever.GetContent($"{defaultBodyFooterRegion.RegionEndpoint}/{Article}", defaultBodyFooterRegion, A<bool>.Ignored, RequestBaseUrl)).Returns(BodyFooterRegionContent);
 
             // Act
             await applicationService.PostMarkupAsync(fakeApplicationModel, "index", Article, defaultFormPostParams, pageModel).ConfigureAwait(false);
@@ -229,7 +232,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
             Assert.Equal(BodyFooterRegionContent, pageModel.PageRegionContentModels.First(x => x.PageRegionType == PageRegion.BodyFooter).Content.Value);
 
             A.CallTo(() => contentRetriever.PostContent($"{RequestBaseUrl}/{fakeApplicationModel.Path.Path}/{Article}", fakeBodyRegion, defaultFormPostParams, RequestBaseUrl)).MustNotHaveHappened();
-            A.CallTo(() => contentRetriever.GetContent($"{defaultBodyFooterRegion.RegionEndpoint}", defaultBodyFooterRegion, A<bool>.Ignored, RequestBaseUrl)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => contentRetriever.GetContent($"{defaultBodyFooterRegion.RegionEndpoint}/{Article}", defaultBodyFooterRegion, A<bool>.Ignored, RequestBaseUrl)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/DFC.Composite.Shell.UnitTests/ServicesTests/OpenIdConnectClientTests.cs
+++ b/DFC.Composite.Shell.UnitTests/ServicesTests/OpenIdConnectClientTests.cs
@@ -1,0 +1,202 @@
+﻿using DFC.Composite.Shell.Services.Auth;
+using DFC.Composite.Shell.Services.Auth.Models;
+using FakeItEasy;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Xunit;
+
+namespace DFC.Composite.Shell.UnitTests.ServicesTests
+{
+    public class OpenIdConnectClientTests
+    {
+        private readonly IOptions<OpenIDConnectSettings> defaultSettings;
+        private readonly SecurityTokenHandler tokenHandler;
+        const string defaultSignInRedirectUrl = "testSignInRedirect.com";
+        const string defaultSignOutRedirectUrl = "testSignOutRedirect.com";
+        private IConfigurationManager<OpenIdConnectConfiguration> configurationManager;
+
+        public OpenIdConnectClientTests()
+        {
+            defaultSettings = Options.Create(new OpenIDConnectSettings
+            {
+                RedirectUrl = defaultSignInRedirectUrl,
+                SignOutRedirectUrl = defaultSignOutRedirectUrl,
+                Issuer = "issuer",
+                AuthdUrl = "auth",
+                AuthorizeUrl = "AuthorizeUrl",
+                ClientId = "clientid",
+                EndSessionUrl = "Endsesison",
+                JWK = "jjjjjjfhfjjfjfjfjfhfjkhdfkhdfkjhskfhsldkjhfskdljfhsdlkfhsdflksdhsdlkfh",
+                Exponent = "AQAB",
+            });
+
+            tokenHandler = A.Fake<SecurityTokenHandler>();
+            configurationManager = A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
+            A.CallTo(() => configurationManager.GetConfigurationAsync(CancellationToken.None)).Returns(
+                new OpenIdConnectConfiguration
+                {
+                    AuthorizationEndpoint = "auth",
+                    EndSessionEndpoint = "end",
+                    Issuer = "issuer",
+                });
+        }
+
+        [Fact]
+        public async Task WhenGetSignInUrlCalledWithoutParameterThenReturnUrlWithDefaultRedirect()
+        {
+            var client = new AzureB2CAuthClient(defaultSettings, tokenHandler, configurationManager);
+
+            var url = await client.GetSignInUrl().ConfigureAwait(false);
+
+            Assert.Contains(defaultSignInRedirectUrl, url, StringComparison.InvariantCultureIgnoreCase);
+
+        }
+
+        [Fact]
+        public async Task WhenGetSignOutUrlCalledWithParameterThenReturnUrlWithSuppliedRedirect()
+        {
+            var redirect = "RedirectFromChild";
+            var client = new AzureB2CAuthClient(defaultSettings, tokenHandler, configurationManager);
+
+            var url = await client.GetSignOutUrl(redirect).ConfigureAwait(false);
+
+            Assert.Contains(redirect, url, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        [Fact]
+        public async Task WhenGetSignOutUrlCalledWithoutParameterThenReturnUrlWithDefaultRedirect()
+        {
+            var client = new AzureB2CAuthClient(defaultSettings, tokenHandler, configurationManager);
+
+            var url = await client.GetSignOutUrl(string.Empty).ConfigureAwait(false);
+
+            Assert.Contains(defaultSignOutRedirectUrl, url, StringComparison.InvariantCultureIgnoreCase);
+
+        }
+
+        [Fact]
+        public async Task WhenGetRegisterUrlCalledWithoutParameterThenReturnUrlWithDefaultRedirect()
+        {
+            var client = new AzureB2CAuthClient(defaultSettings, tokenHandler, configurationManager);
+
+            var url = await client.GetRegisterUrl().ConfigureAwait(false);
+
+            Assert.Contains(defaultSignInRedirectUrl, url, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        [Fact]
+        public async Task WhenValidateTokenCalledThenAttemptToValidateToken()
+        {
+            var client = new AzureB2CAuthClient(defaultSettings, tokenHandler, configurationManager);
+            SecurityToken secToken;
+            var token = await client.ValidateToken("token").ConfigureAwait(true);
+            A.CallTo(() => tokenHandler.ValidateToken(A<string>.Ignored,
+                A<TokenValidationParameters>.That.Matches(x => x.ValidIssuer == defaultSettings.Value.Issuer),
+                out secToken)).MustHaveHappened();
+        }
+
+        [Fact]
+        public async Task
+            WhenValidateTokenCalledAndUseOidConfigDiscoveryThenAttemptToValidateTokenUsingDiscoverySettings()
+        {
+            var settings = Options.Create(new OpenIDConnectSettings
+            {
+                UseOIDCConfigDiscovery = true,
+                OIDCConfigMetaDataUrl = "test",
+                RedirectUrl = defaultSignInRedirectUrl,
+                SignOutRedirectUrl = defaultSignOutRedirectUrl,
+                Issuer = "issuerFromServer",
+                AuthdUrl = "auth",
+                AuthorizeUrl = "AuthorizeUrl",
+                ClientId = "clientid",
+                EndSessionUrl = "Endsesison",
+                JWK = "jjjjjjfhfjjfjfjfjfhfjkhdfkhdfkjhskfhsldkjhfskdljfhsdlkfhsdflksdhsdlkfh",
+                Exponent = "AQAB",
+            });
+
+            var client = new AzureB2CAuthClient(settings, tokenHandler, configurationManager);
+
+            SecurityToken secToken;
+            var token = await client.ValidateToken("token").ConfigureAwait(true);
+            A.CallTo(() => tokenHandler.ValidateToken(A<string>.Ignored,
+                    A<TokenValidationParameters>.That.Matches(x => x.ValidIssuer == "issuer"),
+                    out secToken))
+                .MustHaveHappened();
+        }
+
+        [Fact]
+        public async Task WhenGetSignOutCalledAndUseOidConfigDiscoveryThenUseDiscoverySettings()
+        {
+            var settings = Options.Create(new OpenIDConnectSettings
+            {
+                UseOIDCConfigDiscovery = true,
+                OIDCConfigMetaDataUrl = "test",
+                RedirectUrl = defaultSignInRedirectUrl,
+                SignOutRedirectUrl = defaultSignOutRedirectUrl,
+                Issuer = "issuerFromServer",
+                AuthdUrl = "auth",
+                AuthorizeUrl = "AuthorizeUrl",
+                ClientId = "clientid",
+                EndSessionUrl = "Endsesison",
+                JWK = "jjjjjjfhfjjfjfjfjfhfjkhdfkhdfkjhskfhsldkjhfskdljfhsdlkfhsdflksdhsdlkfh",
+            });
+            
+            var client = new AzureB2CAuthClient(settings, tokenHandler, configurationManager);
+
+            var token = await client.GetSignOutUrl("test").ConfigureAwait(true);
+            A.CallTo(() => configurationManager.GetConfigurationAsync(CancellationToken.None)).MustHaveHappened();
+        }
+
+        [Fact]
+        public async Task WhenGetSignInCalledAndUseOidConfigDiscoveryThenUseDiscoverySettings()
+        {
+            var settings = Options.Create(new OpenIDConnectSettings
+            {
+                UseOIDCConfigDiscovery = true,
+                OIDCConfigMetaDataUrl = "test",
+                RedirectUrl = defaultSignInRedirectUrl,
+                SignOutRedirectUrl = defaultSignOutRedirectUrl,
+                Issuer = "issuerFromServer",
+                AuthdUrl = "auth",
+                AuthorizeUrl = "AuthorizeUrl",
+                ClientId = "clientid",
+                EndSessionUrl = "Endsesison",
+                JWK = "jjjjjjfhfjjfjfjfjfhfjkhdfkhdfkjhskfhsldkjhfskdljfhsdlkfhsdflksdhsdlkfh",
+            });
+
+            var client = new AzureB2CAuthClient(settings, tokenHandler, configurationManager);
+
+            var token = await client.GetSignInUrl().ConfigureAwait(true);
+            A.CallTo(() => configurationManager.GetConfigurationAsync(CancellationToken.None)).MustHaveHappened();
+        }
+
+        [Fact]
+        public async Task WhenGetRegisterUrlCalledAndUseOidConfigDiscoveryThenUseDiscoverySettings()
+        {
+            var settings = Options.Create(new OpenIDConnectSettings
+            {
+                UseOIDCConfigDiscovery = true,
+                OIDCConfigMetaDataUrl = "test",
+                RedirectUrl = defaultSignInRedirectUrl,
+                SignOutRedirectUrl = defaultSignOutRedirectUrl,
+                Issuer = "issuerFromServer",
+                AuthdUrl = "auth",
+                AuthorizeUrl = "AuthorizeUrl",
+                ClientId = "clientid",
+                EndSessionUrl = "Endsesison",
+                JWK = "jjjjjjfhfjjfjfjfjfhfjkhdfkhdfkjhskfhsldkjhfskdljfhsdlkfhsdflksdhsdlkfh",
+            });
+
+            var client = new AzureB2CAuthClient(settings, tokenHandler, configurationManager);
+
+            var token = await client.GetRegisterUrl().ConfigureAwait(true);
+            A.CallTo(() => configurationManager.GetConfigurationAsync(CancellationToken.None)).MustHaveHappened();
+        }
+    }
+}

--- a/DFC.Composite.Shell.Views.UnitTests/Tests/LayoutFullWidthNoMainTests.cs
+++ b/DFC.Composite.Shell.Views.UnitTests/Tests/LayoutFullWidthNoMainTests.cs
@@ -1,0 +1,55 @@
+using DFC.Composite.Shell.Models;
+using DFC.Composite.Shell.Views.Test.Services.ViewRenderer;
+using Microsoft.AspNetCore.Html;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DFC.Composite.Shell.Views.Test.Tests
+{
+    public class LayoutFullWidthNoMainTests : TestBase
+    {
+        private const string _layout = "_LayoutFullWidthNoMain";
+
+        [Fact]
+        public void SideBarLeftAndSideBarRightDoNotAppear()
+        {
+            var model = new PageViewModelResponse
+            {
+                LayoutName = _layout,
+                ContentSidebarLeft = new HtmlString("ContentSideBarLeft"),
+                ContentSidebarRight = new HtmlString("ContentSideBarRight")
+            };
+            var viewBag = new Dictionary<string, object>();            
+            var viewRenderer = new RazorEngineRenderer(ViewRootPath);
+
+            var viewRenderResponse = viewRenderer.Render(@"RenderView", model, viewBag);
+
+            Assert.DoesNotContain(model.ContentSidebarLeft.Value, viewRenderResponse);
+            Assert.DoesNotContain(model.ContentSidebarRight.Value, viewRenderResponse);
+        }
+
+        [Fact]
+        public void ContainsContentFromOtherSections()
+        {
+            var model = new PageViewModelResponse
+            {
+                LayoutName = _layout,
+                ContentHead = new HtmlString("ContentHead"),
+                ContentBodyTop = new HtmlString("ContentBodyTop"),
+                ContentBreadcrumb = new HtmlString("ContentBreadcrumb"),
+                ContentBody = new HtmlString("ContentBody"),
+                ContentBodyFooter = new HtmlString("ContentBodyFooter")
+            };
+            var viewBag = new Dictionary<string, object>();
+            var viewRenderer = new RazorEngineRenderer(ViewRootPath);
+
+            var viewRenderResponse = viewRenderer.Render(@"RenderView", model, viewBag);
+
+            Assert.Contains(model.ContentHead.Value, viewRenderResponse);
+            Assert.Contains(model.ContentBodyTop.Value, viewRenderResponse);
+            Assert.Contains(model.ContentBreadcrumb.Value, viewRenderResponse);
+            Assert.Contains(model.ContentBody.Value, viewRenderResponse);
+            Assert.Contains(model.ContentBodyFooter.Value, viewRenderResponse);
+        }
+    }
+}

--- a/DFC.Composite.Shell/ClientHandlers/CompositeSessionIdDelegatingHandler.cs
+++ b/DFC.Composite.Shell/ClientHandlers/CompositeSessionIdDelegatingHandler.cs
@@ -1,0 +1,42 @@
+﻿using DFC.Composite.Shell.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DFC.Composite.Shell.ClientHandlers
+{
+    public class CompositeSessionIdDelegatingHandler : DelegatingHandler
+    {
+        internal const string HeaderName = "x-dfc-composite-sessionid";
+
+        private readonly IHttpContextAccessor httpContextAccessor;
+        private readonly ITempDataDictionaryFactory tempDataDictionaryFactory;
+
+        public CompositeSessionIdDelegatingHandler(IHttpContextAccessor httpContextAccessor, ITempDataDictionaryFactory tempDataDictionaryFactory)
+        {
+            this.httpContextAccessor = httpContextAccessor;
+            this.tempDataDictionaryFactory = tempDataDictionaryFactory;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var compositeSessionId = httpContextAccessor?.HttpContext?.Request?.Cookies[CompositeSessionIdMiddleware.NcsSessionCookieName];
+
+            if (httpContextAccessor?.HttpContext != null && string.IsNullOrWhiteSpace(compositeSessionId))
+            {
+                var tempData = tempDataDictionaryFactory.GetTempData(httpContextAccessor?.HttpContext);
+
+                compositeSessionId = tempData[HeaderName].ToString();
+            }
+
+            if (request != null && !request.Headers.Contains(HeaderName) && !string.IsNullOrWhiteSpace(compositeSessionId))
+            {
+                request.Headers.Add(HeaderName, compositeSessionId);
+            }
+
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/DFC.Composite.Shell/ClientHandlers/CookieDelegatingHandler.cs
+++ b/DFC.Composite.Shell/ClientHandlers/CookieDelegatingHandler.cs
@@ -35,6 +35,7 @@ namespace DFC.Composite.Shell.ClientHandlers
 
             CopyHeaders(prefix, httpContextAccessor.HttpContext.Request.Headers, request?.Headers);
             CopyHeaders(prefix, httpContextAccessor.HttpContext.Items, request?.Headers);
+            AddTokenHeaderFromCookie(httpContextAccessor.HttpContext, request);
 
             return base.SendAsync(request, cancellationToken);
         }
@@ -135,6 +136,16 @@ namespace DFC.Composite.Shell.ClientHandlers
             {
                 destinationHeaders.Add(HeaderNames.Cookie, cookieValues);
             }
+        }
+
+        private void AddTokenHeaderFromCookie(HttpContext context, HttpRequestMessage message)
+        {
+            if (!context.User.Identity.IsAuthenticated)
+            {
+                return;
+            }
+            var token = context.User.Claims.FirstOrDefault(claim => claim.Type == "bearer")?.Value;
+            message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
     }
 }

--- a/DFC.Composite.Shell/Controllers/ApplicationController.cs
+++ b/DFC.Composite.Shell/Controllers/ApplicationController.cs
@@ -52,7 +52,21 @@ namespace DFC.Composite.Shell.Controllers
 
             if (requestViewModel != null)
             {
-                var requestItems = GetRequestItemModels(requestViewModel);
+                var errorRequestViewModel = new ActionGetRequestModel
+                {
+                    Path = AlertPathName,
+                    Data = $"{(int)HttpStatusCode.NotFound}",
+                };
+                var requestItems = new[]
+                {
+                    requestViewModel,
+                    errorRequestViewModel,
+                    new ActionGetRequestModel
+                    {
+                        Path = AlertPathName,
+                        Data = $"{(int)HttpStatusCode.InternalServerError}",
+                    },
+                };
 
                 foreach (var requestItem in requestItems)
                 {
@@ -101,7 +115,7 @@ namespace DFC.Composite.Shell.Controllers
                         logger.LogWarning($"{nameof(Action)}: {errorString}");
 
                         Response.StatusCode = (int)ex.StatusCode;
-                        requestItems.First(m => m.Data == $"{(int)HttpStatusCode.NotFound}").Data = $"{Response.StatusCode}";
+                        errorRequestViewModel.Data = $"{Response.StatusCode}";
                     }
                     catch (RedirectException ex)
                     {
@@ -236,6 +250,7 @@ namespace DFC.Composite.Shell.Controllers
                 VersionedPathForJQueryBundleMinJs = source.VersionedPathForJQueryBundleMinJs,
                 VersionedPathForAllMinJs = source.VersionedPathForAllMinJs,
                 VersionedPathForDfcDigitalMinJs = source.VersionedPathForDfcDigitalMinJs,
+                VersionedPathForCompUiMinJs = source.VersionedPathForCompUiMinJs,
 
                 ContentBody = GetContent(source, PageRegion.Body),
                 ContentBodyFooter = GetContent(source, PageRegion.BodyFooter),
@@ -260,28 +275,6 @@ namespace DFC.Composite.Shell.Controllers
             }
 
             return new HtmlString(result);
-        }
-
-        private static ActionGetRequestModel[] GetRequestItemModels(ActionGetRequestModel requestViewModel)
-        {
-            var notFoundErrorRequestViewModel = new ActionGetRequestModel
-            {
-                Path = AlertPathName,
-                Data = $"{(int)HttpStatusCode.NotFound}",
-            };
-
-            var internalServerErrorRequestViewModel = new ActionGetRequestModel
-            {
-                Path = AlertPathName,
-                Data = $"{(int)HttpStatusCode.InternalServerError}",
-            };
-
-            return new[]
-            {
-                requestViewModel,
-                notFoundErrorRequestViewModel,
-                internalServerErrorRequestViewModel,
-            };
         }
     }
 }

--- a/DFC.Composite.Shell/Controllers/AuthController.cs
+++ b/DFC.Composite.Shell/Controllers/AuthController.cs
@@ -1,0 +1,130 @@
+﻿using DFC.Composite.Shell.Services.Auth;
+using DFC.Composite.Shell.Services.Auth.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace DFC.Composite.Shell.Controllers
+{
+    public class AuthController : Controller
+    {
+        public const string RedirectSessionKey = "RedirectSession";
+        private readonly IOpenIdConnectClient authClient;
+        private readonly ILogger<AuthController> logger;
+        private readonly AuthSettings settings;
+
+        public AuthController(IOpenIdConnectClient client, ILogger<AuthController> logger, IOptions<AuthSettings> settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+            authClient = client;
+            this.logger = logger;
+            this.settings = settings.Value;
+        }
+
+        public async Task<IActionResult> SignIn(string redirectUrl)
+        {
+            SetRedirectUrl(redirectUrl);
+            var signInUrl = await authClient.GetSignInUrl().ConfigureAwait(false);
+            return Redirect(signInUrl);
+        }
+
+        public async Task<IActionResult> SignOut(string redirectUrl)
+        {
+            SetRedirectUrl(redirectUrl);
+            var signInUrl = await authClient.GetSignOutUrl(redirectUrl).ConfigureAwait(false);
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme).ConfigureAwait(false);
+            return Redirect(signInUrl);
+        }
+
+        public async Task<IActionResult> Auth(string id_token)
+        {
+            JwtSecurityToken validatedToken ;//= new JwtSecurityToken("");
+            try
+            {
+                validatedToken = await authClient.ValidateToken(id_token).ConfigureAwait(false);
+            }
+            catch (System.Exception ex)
+            {
+                logger.LogError(ex, "Failed to validate auth token.");
+                throw;
+            }
+
+            var claims = new List<Claim>
+            {
+                new Claim("CustomerId", validatedToken.Claims.FirstOrDefault(claim => claim.Type == "customerId")?.Value),
+                new Claim(ClaimTypes.Email, validatedToken.Claims.FirstOrDefault(claim => claim.Type == "email")?.Value),
+                new Claim(ClaimTypes.GivenName, validatedToken.Claims.FirstOrDefault(claim => claim.Type == "given_name")?.Value),
+                new Claim(ClaimTypes.Surname, validatedToken.Claims.FirstOrDefault(claim => claim.Type == "family_name")?.Value),
+            };
+
+            var expiryTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            expiryTime = expiryTime.AddSeconds(double.Parse(validatedToken.Claims.First(claim => claim.Type == "exp").Value, new DateTimeFormatInfo()));
+            var authProperties = new AuthenticationProperties()
+            {
+                AllowRefresh = false,
+                ExpiresUtc = expiryTime,
+                IsPersistent = true,
+            };
+
+            await HttpContext.SignInAsync(new ClaimsPrincipal(new ClaimsIdentity(new List<Claim> { new Claim("bearer", CreateChildAppToken(claims, expiryTime)) }, CookieAuthenticationDefaults.AuthenticationScheme)), authProperties).ConfigureAwait(false);
+
+            return Redirect(GetRedirectUrl());
+        }
+
+        public async Task<IActionResult> Register(string redirectUrl)
+        {
+            SetRedirectUrl(redirectUrl);
+            var signInUrl = await authClient.GetRegisterUrl().ConfigureAwait(false);
+            return Redirect(signInUrl);
+        }
+
+        private string CreateChildAppToken(List<Claim> claims, DateTime expiryTime)
+        {
+            var now = DateTime.UtcNow;
+            var signingKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(settings.ClientSecret));
+
+            var credentials = new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256);
+
+            var jwt = new JwtSecurityToken(
+                issuer: settings.Issuer,
+                audience: settings.Audience,
+                claims: claims,
+                notBefore: now,
+                expires: expiryTime,
+                signingCredentials: credentials);
+            var encodedJwt = new JwtSecurityTokenHandler().WriteToken(jwt);
+            return encodedJwt;
+        }
+
+        private void SetRedirectUrl(string redirectUrl)
+        {
+            if (!string.IsNullOrEmpty(redirectUrl))
+            {
+                HttpContext.Session.SetString(RedirectSessionKey, redirectUrl);
+            }
+        }
+
+        private string GetRedirectUrl()
+        {
+            var url = HttpContext.Session.GetString(RedirectSessionKey);
+            return string.IsNullOrEmpty(url) ? settings.DefaultRedirectUrl : url;
+        }
+    }
+}

--- a/DFC.Composite.Shell/Extensions/CompositeSessionIdMiddlewareExtension.cs
+++ b/DFC.Composite.Shell/Extensions/CompositeSessionIdMiddlewareExtension.cs
@@ -1,0 +1,13 @@
+﻿using DFC.Composite.Shell.Middleware;
+using Microsoft.AspNetCore.Builder;
+
+namespace DFC.Composite.Shell.Extensions
+{
+    public static class CompositeSessionIdMiddlewareExtension
+    {
+        public static IApplicationBuilder UseCompositeSessionId(this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<CompositeSessionIdMiddleware>();
+        }
+    }
+}

--- a/DFC.Composite.Shell/Extensions/VersionedFilesExtensions.cs
+++ b/DFC.Composite.Shell/Extensions/VersionedFilesExtensions.cs
@@ -17,6 +17,7 @@ namespace DFC.Composite.Shell.Extensions
                 VersionedPathForJQueryBundleMinJs = versionedFiles?.VersionedPathForJQueryBundleMinJs,
                 VersionedPathForAllMinJs = versionedFiles?.VersionedPathForAllMinJs,
                 VersionedPathForDfcDigitalMinJs = versionedFiles?.VersionedPathForDfcDigitalMinJs,
+                VersionedPathForCompUiMinJs = versionedFiles?.VersionedPathForCompUiMinJs,
             };
         }
     }

--- a/DFC.Composite.Shell/Middleware/CompositeSessionIdMiddleware.cs
+++ b/DFC.Composite.Shell/Middleware/CompositeSessionIdMiddleware.cs
@@ -1,0 +1,47 @@
+﻿using DFC.Composite.Shell.ClientHandlers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using System;
+using System.Threading.Tasks;
+
+namespace DFC.Composite.Shell.Middleware
+{
+    public class CompositeSessionIdMiddleware
+    {
+        internal const string NcsSessionCookieName = "ncs_session_cookie";
+
+        private readonly RequestDelegate next;
+
+        public CompositeSessionIdMiddleware(RequestDelegate next)
+        {
+            this.next = next;
+        }
+
+        public async Task Invoke(HttpContext httpContext, ITempDataDictionaryFactory tempDataDictionaryFactory)
+        {
+            string compositeSessionId = httpContext?.Request.Cookies[NcsSessionCookieName];
+
+            if (string.IsNullOrWhiteSpace(compositeSessionId))
+            {
+                compositeSessionId = Guid.NewGuid().ToString();
+            }
+
+            var cookieOptions = new CookieOptions
+            {
+                Expires = DateTime.Now.AddDays(28),
+                Secure = true,
+                SameSite = SameSiteMode.None,
+            };
+
+            httpContext?.Response.Cookies.Append(NcsSessionCookieName, compositeSessionId, cookieOptions);
+
+            var tempData = tempDataDictionaryFactory?.GetTempData(httpContext);
+            if (tempData != null)
+            {
+                tempData[CompositeSessionIdDelegatingHandler.HeaderName] = compositeSessionId;
+            }
+
+            await next(httpContext).ConfigureAwait(false);
+        }
+    }
+}

--- a/DFC.Composite.Shell/Models/PageViewModelResponse.cs
+++ b/DFC.Composite.Shell/Models/PageViewModelResponse.cs
@@ -20,6 +20,8 @@ namespace DFC.Composite.Shell.Models
 
         public string VersionedPathForDfcDigitalMinJs { get; set; }
 
+        public string VersionedPathForCompUiMinJs { get; set; }
+
         public string Path { get; set; }
 
         public string LayoutName { get; set; } = "_LayoutFullWidth";

--- a/DFC.Composite.Shell/Policies.Options/AuthClientOptions.cs
+++ b/DFC.Composite.Shell/Policies.Options/AuthClientOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace DFC.Composite.Shell.Policies.Options
+{
+    public class AuthClientOptions : HttpClientOptions
+    {
+    }
+}

--- a/DFC.Composite.Shell/Views/Home/Index.cshtml
+++ b/DFC.Composite.Shell/Views/Home/Index.cshtml
@@ -11,6 +11,7 @@
     ViewData["VersionedPathForJQueryBundleMinJs"] = Model.VersionedPathForJQueryBundleMinJs;
     ViewData["VersionedPathForAllMinJs"] = Model.VersionedPathForAllMinJs;
     ViewData["VersionedPathForDfcDigitalMinJs"] = Model.VersionedPathForDfcDigitalMinJs;
+    ViewData["VersionedPathForCompUiMinJs"] = Model.VersionedPathForCompUiMinJs;
 }
 <div class="govuk-width-container">
     <div class="govuk-grid-row">

--- a/DFC.Composite.Shell/Views/Shared/Application/RenderView.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/Application/RenderView.cshtml
@@ -10,6 +10,7 @@
     ViewBag.VersionedPathForJQueryBundleMinJs = Model.VersionedPathForJQueryBundleMinJs;
     ViewBag.VersionedPathForAllMinJs = Model.VersionedPathForAllMinJs;
     ViewBag.VersionedPathForDfcDigitalMinJs = Model.VersionedPathForDfcDigitalMinJs;
+    ViewBag.VersionedPathForCompUiMinJs = Model.VersionedPathForCompUiMinJs;
 }
 
 @{

--- a/DFC.Composite.Shell/Views/Shared/_ErrorSummary.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_ErrorSummary.cshtml
@@ -1,38 +1,12 @@
-﻿@if (!ViewData.ModelState.IsValid)
-{
-    ViewBag.Title = "Error: " + @ViewBag.Title;
-
-    <script type="text/javascript" nws-csp-add-nonce="true">
-        document.title = '@ViewBag.Title';
-    </script>
-
-    <br />
-
-    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-        </h2>
-        <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-                @foreach (var key in ViewData.ModelState.Keys)
-                {
-                    foreach (var error in ViewData.ModelState[key].Errors)
-                    {
-                        if (string.IsNullOrWhiteSpace(key))
-                        {
-                            <li>
-                                @error.ErrorMessage
-                            </li>
-                        }
-                        else
-                        {
-                            <li>
-                                <a href="#@key">@error.ErrorMessage</a>
-                            </li>
-                        }
-                    }
-                }
-            </ul>
-        </div>
-    </div>
+﻿@{
+    var showHideErrorSummary = "dfc-composite-shell-hide";
 }
+
+<div id="compuiShell-ErrorSummary" class="govuk-error-summary @showHideErrorSummary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list" />
+    </div>
+</div>

--- a/DFC.Composite.Shell/Views/Shared/_JQueryInitialise.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_JQueryInitialise.cshtml
@@ -7,6 +7,7 @@
     string VersionedPathForJQueryBundleMinJs = ViewData["VersionedPathForJQueryBundleMinJs"].ToString();
     string VersionedPathForAllMinJs = ViewData["VersionedPathForAllMinJs"].ToString();
     string VersionedPathForDfcDigitalMinJs = ViewData["VersionedPathForDfcDigitalMinJs"].ToString();
+    string VersionedPathForCompUiMinJs = ViewData["VersionedPathForCompUiMinJs"].ToString();
 }
 
 <script src="@(VersionedPathForJQueryBundleMinJs)" type="text/javascript" nws-csp-add-nonce="true"></script>
@@ -15,3 +16,5 @@
 <script nws-csp-add-nonce="true">window.GOVUKFrontend.initAll()</script>
 
 <script src="@(VersionedPathForDfcDigitalMinJs)" nws-csp-add-nonce="true"></script>
+
+<script src="@(VersionedPathForCompUiMinJs)" nws-csp-add-nonce="true"></script>

--- a/DFC.Composite.Shell/Views/Shared/_LayoutFullWidthNoMain.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_LayoutFullWidthNoMain.cshtml
@@ -1,0 +1,71 @@
+﻿<!DOCTYPE html>
+<html lang="en-gb" class="govuk-template ">
+
+<head>
+    <partial name="_Head" />
+
+    @if (IsSectionDefined("Head"))
+    {
+        @RenderSection("Head", required: false)
+    }
+
+    @await Component.InvokeAsync("AppInsights", null)
+</head>
+
+<body class="govuk-template__body ">
+    <partial name="_GovUkHeader" />
+
+    <div class="govuk-width-container">
+
+        <partial name="_PhaseBanner" />
+
+        <partial name="_ErrorSummary" />
+    </div>
+
+    @if (IsSectionDefined("BodyTop"))
+    {
+        @RenderSection("BodyTop", required: false)
+    }
+
+    @if (IsSectionDefined("HeroBanner"))
+    {
+        @RenderSection("HeroBanner", required: false)
+    }
+
+
+    @if (IsSectionDefined("Breadcrumb"))
+    {
+        @RenderSection("Breadcrumb", required: false)
+    }
+
+
+    @if (IsSectionDefined("Body"))
+    {
+        @RenderSection("Body", required: false)
+    }
+
+    @RenderBody()
+
+    @{
+        if (IsSectionDefined("SideBarLeft"))
+        {
+            IgnoreSection("SideBarLeft");
+        }
+        if (IsSectionDefined("SideBarRight"))
+        {
+            IgnoreSection("SideBarRight");
+        }
+    }
+
+@if (IsSectionDefined("BodyFooter"))
+{
+    @RenderSection("BodyFooter", required: false)
+}
+
+    <partial name="_GovUkFooter" />
+
+    <partial name="_JQueryInitialise" />
+
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/DFC.Composite.Shell/appsettings-template.json
+++ b/DFC.Composite.Shell/appsettings-template.json
@@ -42,5 +42,25 @@
     "Timeout": "00:00:30",
     "BaseAddress": null
   },
-  "ApimProxyAddress": "http://dfc-api-url"
+  "ApimProxyAddress": "http://dfc-api-url",
+  "OIDCSettings": {
+    "OIDCConfigMetaDataUrl": "",
+    "UseOIDCConfigDiscovery": true,
+    "AuthorizeUrl": "",
+    "JWKsUrl": "",
+    "JWK": "",
+    "Issuer": "",
+    "ClientId": "",
+    "RedirectUrl": "https://localhost:44383/auth/auth",
+    "SignOutRedirectUrl": "https://localhost:44383/your-account",
+    "AuthdUrl": "https://localhost:44383/your-account",
+    "LogPersonalInfo": true,
+    "Exponent": "AQAB"
+  },
+  "AuthSettings": {
+    "ClientSecret": "test",
+    "Issuer": "https://localhost:44383",
+    "Audience": "CompositeChild",
+    "DefaultRedirectUrl": "/your-account"
+  }
 }

--- a/DFC.Composite.Shell/libman.json
+++ b/DFC.Composite.Shell/libman.json
@@ -1,21 +1,5 @@
 {
   "version": "1.0",
   "defaultProvider": "cdnjs",
-  "libraries": [
-    {
-      "provider": "cdnjs",
-      "library": "jquery@3.3.1",
-      "destination": "wwwroot/lib/jquery"
-    },
-    {
-      "provider": "cdnjs",
-      "library": "jquery-validate@1.19.0",
-      "destination": "wwwroot/lib/jquery-validation/"
-    },
-    {
-      "provider": "cdnjs",
-      "library": "jquery-validation-unobtrusive@3.2.11",
-      "destination": "wwwroot/lib/jquery-validation-unobtrusive/"
-    }
-  ]
+  "libraries": []
 }

--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -43,6 +43,18 @@
         },
         "enableAlerts": {
             "value": __EnableAzureMonitorAlerting__
+        },
+        "AuthClientSecret": {
+            "value": "__AuthClientSecret__"
+        },
+        "OIDCClientId": {
+            "value": "__OIDCClientId__"
+        },
+        "OIDCLogPersonalInfo": {
+            "value": __OIDCLogPersonalInfo__
+        },
+        "OIDCOIDCConfigMetaDataUrl": {
+            "value": "__OIDCOIDCConfigMetaDataUrl__"
         }
     }
 }

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -49,6 +49,18 @@
             "metadata": {
                 "description": "Enable or disable alerting"
             }
+        },
+        "AuthClientSecret": {
+            "type": "string"
+        },
+        "OIDCClientId": {
+            "type": "string"
+        },
+        "OIDCLogPersonalInfo": {
+            "type": "bool"
+        },
+        "OIDCOIDCConfigMetaDataUrl": {
+            "type": "string"
         }
     },
     "variables": {
@@ -141,104 +153,168 @@
                         "value": "app"
                     },
                     "appServiceAppSettings": {
-                      "value": [
-                        {
-                          "name": "MSDEPLOY_RENAME_LOCKED_FILES",
-                          "value": "1"
-                        },
-                        {
-                          "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                          "value": "[reference(variables('AppServiceAppInsightsName')).outputs.InstrumentationKey.value]"
-                        },
-                        {
-                          "name": "ApplicationInsights__ScriptResourceAddress",
-                          "value": "https://az416426.vo.msecnd.net/scripts/"
-                        },
-                        {
-                          "name": "ApplicationInsights__ConnectSources",
-                          "value": "https://dc.services.visualstudio.com/"
-                        },
-                        {
-                          "name": "AzureWebJobsStorage",
-                          "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('CompositeUiSharedStorageAccountName'),';AccountKey=',listKeys(resourceId(parameters('CompositeUiSharedResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('CompositeUiSharedStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"
-                        },
-                        {
-                          "name": "ApimProxyAddress",
-                          "value": "[parameters('ApimProxyAddress')]"
-                        },
-                        {
-                          "name": "ApplicationClientOptions__BaseAddress",
-                          "value": null
-                        },
-                        {
-                          "name": "ApplicationClientOptions__Timeout",
-                          "value": "00:00:10"
-                        },
-                        {
-                          "name": "BrandingAssetsCdn",
-                          "value": "[parameters('CompositeUiCdnUrl')]"
-                        },
-                        {
-                          "name": "Logging__LogLevel__Default",
-                          "value": "Error"
-                        },
-                        {
-                          "name": "PathClientOptions__BaseAddress",
-                          "value": "[variables('CompositePathUrl')]"
-                        },
-                        {
-                          "name": "PathClientOptions__Timeout",
-                          "value": "00:00:10"
-                        },
-                        {
-                          "name": "PathClientOptions__ApiKey",
-                          "value": "[parameters('ApimKey')]"
-                        },
-                        {
-                          "name": "Policies__HttpCircuitBreaker__DurationOfBreak",
-                          "value": "00:01:00"
-                        },
-                        {
-                          "name": "Policies__HttpCircuitBreaker__ExceptionsAllowedBeforeBreaking",
-                          "value": 3
-                        },
-                        {
-                          "name": "Policies__HttpRetry__BackoffPower",
-                          "value": 3
-                        },
-                        {
-                          "name": "Policies__HttpRetry__Count",
-                          "value": 3
-                        },
-                        {
-                          "name": "RegionClientOptions__BaseAddress",
-                          "value": "[variables('CompositeRegionUrl')]"
-                        },
-                        {
-                          "name": "RegionClientOptions__Timeout",
-                          "value": "00:00:10"
-                        },
-                        {
-                          "name": "RegionClientOptions__ApiKey",
-                          "value": "[parameters('ApimKey')]"
-                        },
-                        {
-                          "name": "RobotClientOptions__BaseAddress",
-                          "value": null
-                        },
-                        {
-                          "name": "RobotClientOptions__Timeout",
-                          "value": "00:00:10"
-                        },
-                        {
-                          "name": "SitemapClientOptions__BaseAddress",
-                          "value": null
-                        },
-                        {
-                          "name": "SitemapClientOptions__Timeout",
-                          "value": "00:00:10"
-                        }
-                      ]
+                        "value": [
+                            {
+                                "name": "MSDEPLOY_RENAME_LOCKED_FILES",
+                                "value": "1"
+                            },
+                            {
+                                "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                                "value": "[reference(variables('AppServiceAppInsightsName')).outputs.InstrumentationKey.value]"
+                            },
+                            {
+                                "name": "ApplicationInsights__ScriptResourceAddress",
+                                "value": "https://az416426.vo.msecnd.net/scripts/"
+                            },
+                            {
+                                "name": "ApplicationInsights__ConnectSources",
+                                "value": "https://dc.services.visualstudio.com/"
+                            },
+                            {
+                                "name": "AzureWebJobsStorage",
+                                "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('CompositeUiSharedStorageAccountName'),';AccountKey=',listKeys(resourceId(parameters('CompositeUiSharedResourceGroup'), 'Microsoft.Storage/storageAccounts', parameters('CompositeUiSharedStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"
+                            },
+                            {
+                                "name": "ApimProxyAddress",
+                                "value": "[parameters('ApimProxyAddress')]"
+                            },
+                            {
+                                "name": "ApplicationClientOptions__BaseAddress",
+                                "value": null
+                            },
+                            {
+                                "name": "ApplicationClientOptions__Timeout",
+                                "value": "00:00:10"
+                            },
+                            {
+                                "name": "BrandingAssetsCdn",
+                                "value": "[parameters('CompositeUiCdnUrl')]"
+                            },
+                            {
+                                "name": "Logging__LogLevel__Default",
+                                "value": "Error"
+                            },
+                            {
+                                "name": "PathClientOptions__BaseAddress",
+                                "value": "[variables('CompositePathUrl')]"
+                            },
+                            {
+                                "name": "PathClientOptions__Timeout",
+                                "value": "00:00:10"
+                            },
+                            {
+                                "name": "PathClientOptions__ApiKey",
+                                "value": "[parameters('ApimKey')]"
+                            },
+                            {
+                                "name": "Policies__HttpCircuitBreaker__DurationOfBreak",
+                                "value": "00:01:00"
+                            },
+                            {
+                                "name": "Policies__HttpCircuitBreaker__ExceptionsAllowedBeforeBreaking",
+                                "value": 3
+                            },
+                            {
+                                "name": "Policies__HttpRetry__BackoffPower",
+                                "value": 3
+                            },
+                            {
+                                "name": "Policies__HttpRetry__Count",
+                                "value": 3
+                            },
+                            {
+                                "name": "RegionClientOptions__BaseAddress",
+                                "value": "[variables('CompositeRegionUrl')]"
+                            },
+                            {
+                                "name": "RegionClientOptions__Timeout",
+                                "value": "00:00:10"
+                            },
+                            {
+                                "name": "RegionClientOptions__ApiKey",
+                                "value": "[parameters('ApimKey')]"
+                            },
+                            {
+                                "name": "RobotClientOptions__BaseAddress",
+                                "value": null
+                            },
+                            {
+                                "name": "RobotClientOptions__Timeout",
+                                "value": "00:00:10"
+                            },
+                            {
+                                "name": "SitemapClientOptions__BaseAddress",
+                                "value": null
+                            },
+                            {
+                                "name": "SitemapClientOptions__Timeout",
+                                "value": "00:00:10"
+                            },
+                            {
+                                "name": "AuthSettings__ClientSecret",
+                                "value": "[parameters('AuthClientSecret')]"
+                            },
+                            {
+                                "name": "AuthSettings__Issuer",
+                                "value": "[concat('https://', variables('WebAppName'), '.azurewebsites.net')]"
+                            },
+                            {
+                                "name": "AuthSettings__Audience",
+                                "value": "CompositeChild"
+                            },
+                            {
+                                "name": "AuthSettings__DefaultRedirectUrl",
+                                "value": "/your-account"
+                            },
+                            {
+                                "name": "OIDCSettings__OIDCConfigMetaDataUrl",
+                                "value": "[parameters('OIDCOIDCConfigMetaDataUrl')]"
+                            },
+                            {
+                                "name": "OIDCSettings__UseOIDCConfigDiscovery",
+                                "value": true
+                            },
+                            {
+                                "name": "OIDCSettings__AuthorizeUrl",
+                                "value": "tbc"
+                            },
+                            {
+                                "name": "OIDCSettings__JWKsUrl",
+                                "value": "tbc"
+                            },
+                            {
+                                "name": "OIDCSettings__JWK",
+                                "value": "tbc"
+                            },
+                            {
+                                "name": "OIDCSettings__Issuer",
+                                "value": "tbc"
+                            },
+                            {
+                                "name": "OIDCSettings__ClientId",
+                                "value": "[parameters('OIDCClientId')]"
+                            },
+                            {
+                                "name": "OIDCSettings__RedirectUrl",
+                                "value": "[concat('https://', variables('WebAppName'), '.azurewebsites.net/auth/auth')]"
+                            },
+                            {
+                                "name": "OIDCSettings__SignOutRedirectUrl",
+                                "value": "[concat('https://', variables('WebAppName'), '.azurewebsites.net')]"
+                            },
+                            {
+                                "name": "OIDCSettings__AuthdUrl",
+                                "value": "[concat('https://', variables('WebAppName'), '.azurewebsites.net/your-account')]"
+                            },
+                            {
+                                "name": "OIDCSettings__LogPersonalInfo",
+                                "value": "[parameters('OIDCLogPersonalInfo')]"
+                            },
+                            {
+                                "name": "OIDCSettings__Exponent",
+                                "value": "AQAB"
+                            }
+                        ]
                     }
                 }
             },
@@ -247,87 +323,88 @@
             ]
         },
         {
-          "apiVersion": "2019-05-01",
-          "name": "[concat(variables('AppServiceAppInsightsName'), '-metric-exceptions')]",
-          "type": "Microsoft.Resources/deployments",
-          "dependsOn": [
-              "[variables('AppServiceAppInsightsName')]"
-          ],
-          "properties": {
-              "mode": "Incremental",
-              "templateLink": {
-                  "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/metric-alerts.json')]",
-                  "contentVersion": "1.0.0.0"
-              },
-              "parameters": {
-                  "enabled": {
-                      "value": "[parameters('enableAlerts')]"
-                  },
-                  "alertName": {
-                      "value": "[concat(variables('AppServiceAppInsightsName'), '-metric-exceptions')]"
-                  },
-                  "alertSeverity": {
-                      "value": 3
-                  },
-                  "metricName": {
-                      "value": "exceptions/count"
-                  },
-                  "operator": {
-                      "value": "GreaterThan"
-                  },
-                  "threshold": {
-                      "value": "0"
-                  },
-                  "aggregation": {
-                      "value": "Count"
-                  },
-                  "windowSize": {
-                      "value": "PT5M"
-                  },
-                  "evaluationFrequency": {
-                      "value": "PT1M"
-                  },
-                  "actionGroupName": {
-                      "value": "[variables('ActionGroupName')]"
-                  },
-                  "actionGroupResourceGroup": {
-                      "value": "[parameters('CompositeUiSharedResourceGroup')]"
-                  },
-                  "resourceId": {
-                      "value": "[resourceId('Microsoft.Insights/Components', variables('AppServiceAppInsightsName'))]"
-                  }
-              }
-          }
-      },
-      {
-          "apiVersion": "2019-05-01",
-          "name": "[concat(variables('AppServiceAppInsightsName'), '-failure-anomaly-v2')]",
-          "type": "Microsoft.Resources/deployments",
-          "dependsOn": [
-              "[variables('AppServiceAppInsightsName')]"
-          ],
-          "properties": {
-              "mode": "Incremental",
-              "templateLink": {
-                  "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/failure-anomaly-rule.json')]",
-                  "contentVersion": "1.0.0.0"
-              },
-              "parameters": {
-                  "alertName": {
-                      "value": "[concat(variables('AppServiceAppInsightsName'), '-failure-anomaly-v2')]"
-                  },
-                  "enabled": {
-                      "value": "[parameters('enableAlerts')]"
-                  },
-                  "resourceId": {
-                      "value": "[resourceId('Microsoft.Insights/Components', variables('AppServiceAppInsightsName'))]"
-                  },
-                  "actionGroupId": {
-                      "value": "[resourceId(parameters('CompositeUiSharedResourceGroup'), 'microsoft.insights/actionGroups', variables('ActionGroupName'))]"
-                  }
-              }
-          }
-      }
+            "apiVersion": "2019-05-01",
+            "name": "[concat(variables('AppServiceAppInsightsName'), '-metric-exceptions')]",
+            "type": "Microsoft.Resources/deployments",
+            "dependsOn": [
+                "[variables('AppServiceAppInsightsName')]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/metric-alerts.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "enabled": {
+                        "value": "[parameters('enableAlerts')]"
+                    },
+                    "alertName": {
+                        "value": "[concat(variables('AppServiceAppInsightsName'), '-metric-exceptions')]"
+                    },
+                    "alertSeverity": {
+                        "value": 3
+                    },
+                    "metricName": {
+                        "value": "exceptions/count"
+                    },
+                    "operator": {
+                        "value": "GreaterThan"
+                    },
+                    "threshold": {
+                        "value": "0"
+                    },
+                    "aggregation": {
+                        "value": "Count"
+                    },
+                    "windowSize": {
+                        "value": "PT5M"
+                    },
+                    "evaluationFrequency": {
+                        "value": "PT1M"
+                    },
+                    "actionGroupName": {
+                        "value": "[variables('ActionGroupName')]"
+                    },
+                    "actionGroupResourceGroup": {
+                        "value": "[parameters('CompositeUiSharedResourceGroup')]"
+                    },
+                    "resourceId": {
+                        "value": "[resourceId('Microsoft.Insights/Components', variables('AppServiceAppInsightsName'))]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2019-05-01",
+            "name": "[concat(variables('AppServiceAppInsightsName'), '-failure-anomaly-v2')]",
+            "type": "Microsoft.Resources/deployments",
+            "dependsOn": [
+                "[variables('AppServiceAppInsightsName')]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/failure-anomaly-rule.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "alertName": {
+                        "value": "[concat(variables('AppServiceAppInsightsName'), '-failure-anomaly-v2')]"
+                    },
+                    "enabled": {
+                        "value": "[parameters('enableAlerts')]"
+                    },
+                    "resourceId": {
+                        "value": "[resourceId('Microsoft.Insights/Components', variables('AppServiceAppInsightsName'))]"
+                    },
+                    "actionGroupId": {
+                        "value": "[resourceId(parameters('CompositeUiSharedResourceGroup'), 'microsoft.insights/actionGroups', variables('ActionGroupName'))]"
+                    }
+                }
+            }
+        }
     ],
-    "outputs": {}
+    "outputs": {
+    }
 }

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -28,6 +28,18 @@
         },
         "enableAlerts": {
             "value": false
+        },
+        "AuthClientSecret": {
+            "value": "12345678"
+        },
+        "OIDCClientId": {
+            "value": "1244444"
+        },
+        "OIDCLogPersonalInfo": {
+            "value": false
+        },
+        "OIDCOIDCConfigMetaDataUrl": {
+            "value": "https://foo-compui-shell.azurewebsites.net"
         }
     }
 }


### PR DESCRIPTION
### This release contains the following changes
- Full width template with no main
- dded exception handler to child app Health response (CUSI-11)
- Relay the query string to all regions (CUSI-26)
- Now uses JsonPatchDocument to apply Region health status update (CUSI-20)
- Made a minor amendment to the code to simplify error → Alert transitions (CUSI-28)
- Added serco.com as an allowable iframe source for CSP (DFCC-317)
- Added CompUI asset from CDN to the JQuery initialize partial (DFCC-316)
- Updated child app Sitemap retrieval to ignore empty responses from child apps when no content (DFCC-269)
- Fix to ensure HtmlHead region is called after a post (DFCC-263)
- Added Auth service
- Updated error summary for use by generic scripts (DFCC-359)
- Added id to error summary div for use in validation scripts (DFCC-339)
- Added session id header to all child app request (DFCC-412)