### PR TITLE
Removed vibrate and usermedia from feature policy

### DIFF
--- a/DFC.Composite.Shell/Startup.cs
+++ b/DFC.Composite.Shell/Startup.cs
@@ -118,7 +118,7 @@ namespace DFC.Composite.Shell
 
             app.Use(async (context, next) =>
             {
-                context.Response.Headers.Add("Feature-Policy", "vibrate 'self'; usermedia *; sync-xhr 'self'");
+                context.Response.Headers.Add("Feature-Policy", "sync-xhr 'self'");
                 context.Response.Headers.Add("Expect-CT", "max-age=86400, enforce");
                 context.Response.Headers.Add("X-Permitted-Cross-Domain-Policies", "none");
                 await next().ConfigureAwait(false);


### PR DESCRIPTION
Removed vibrate and usermedia from feature policy as it is not currently supported by browsers. 