### PR TITLE
Bug/dfc 13131 format exception when adding user agent hotfix

### DIFF
--- a/DFC.Composite.Shell.IntegrationTests/Tests/ExternalApplicationTests.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Tests/ExternalApplicationTests.cs
@@ -1,4 +1,5 @@
 ﻿using DFC.Composite.Shell.Integration.Test.Framework;
+using Microsoft.Net.Http.Headers;
 using System;
 using System.Net;
 using System.Threading.Tasks;
@@ -20,6 +21,22 @@ namespace DFC.Composite.Shell.Integration.Test
         {
             factory.ClientOptions.AllowAutoRedirect = false;
             var client = factory.CreateClientWithWebHostBuilder();
+
+            var response = await client.GetAsync(new Uri("/externalpath1", UriKind.Relative)).ConfigureAwait(false);
+
+            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            Assert.Equal("http://www.externalpath1.com/", response.Headers.Location.AbsoluteUri);
+        }
+
+        [Theory]
+        [InlineData("product; (product with ;)")]
+        [InlineData("product (product with out ;)")]
+        public async Task CanRedirectToExternalUrlWithUserAgent(string userAgent)
+        {
+            factory.ClientOptions.AllowAutoRedirect = false;
+            var client = factory.CreateClientWithWebHostBuilder();
+
+            var validUserAgent = client.DefaultRequestHeaders.TryAddWithoutValidation(HeaderNames.UserAgent, userAgent);
 
             var response = await client.GetAsync(new Uri("/externalpath1", UriKind.Relative)).ConfigureAwait(false);
 

--- a/DFC.Composite.Shell/ClientHandlers/UserAgentDelegatingHandler.cs
+++ b/DFC.Composite.Shell/ClientHandlers/UserAgentDelegatingHandler.cs
@@ -27,7 +27,13 @@ namespace DFC.Composite.Shell.ClientHandlers
                 foreach (var item in httpContextAccessor.HttpContext.Request.Headers[HeaderNames.UserAgent])
                 {
                     logger.LogInformation($"Setting UserAgent to {item}");
-                    request.Headers.Add(HeaderNames.UserAgent, item);
+
+                    //Added without validation because external host headers with a ; after the product name were failing
+                    //+http://code.google.com/appengine; - would fail with a format exception, if the just the add method is used.
+                    if (!request.Headers.TryAddWithoutValidation(HeaderNames.UserAgent, item))
+                    {
+                        logger.LogWarning($"Cound not add {HeaderNames.UserAgent} - {item}");
+                    }
                 }
             }
 


### PR DESCRIPTION
Changed to use the TryAddWithoutValidation method when adding external useragent headers to forwarding requests.
This is to prevent format exceptions for useragent from some external requests