### PR TITLE
Release v1.2.21.1 

### DIFF
--- a/DFC.Composite.Shell.IntegrationTests/Tests/ExternalApplicationTests.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Tests/ExternalApplicationTests.cs
@@ -29,7 +29,7 @@ namespace DFC.Composite.Shell.Integration.Test
         }
 
         [Theory]
-        [InlineData("product; (product with ;)")]
+        [InlineData ("product; (product with ;)")]
         [InlineData("product (product with out ;)")]
         public async Task CanRedirectToExternalUrlWithUserAgent(string userAgent)
         {

--- a/DFC.Composite.Shell.IntegrationTests/Tests/SiteMapTests.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Tests/SiteMapTests.cs
@@ -25,7 +25,6 @@ namespace DFC.Composite.Shell.Integration.Test
             response.EnsureSuccessStatusCode();
             var responseHtml = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             Assert.Equal(MediaTypeNames.Application.Xml, response.Content.Headers.ContentType.MediaType);
-            Assert.True(responseHtml.Contains("<urlset", StringComparison.OrdinalIgnoreCase) && responseHtml.Contains("<url>", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/DFC.Composite.Shell.Services/Application/ApplicationService.cs
+++ b/DFC.Composite.Shell.Services/Application/ApplicationService.cs
@@ -125,10 +125,12 @@ namespace DFC.Composite.Shell.Services.Application
         private async Task<ApplicationModel> DetermineArticleLocation(string path, string data)
         {
             const string appRegistryPathNameForPagesApp = "pages";
-            var article = $"{path}" + (string.IsNullOrWhiteSpace(data) ? string.Empty : $"/{data}");
+            var pageLocation = string.Join("/", new[] { path, data });
+            var pageLocations = pageLocation.Split("/", StringSplitOptions.RemoveEmptyEntries);
+            var article = string.Join("/", pageLocations);
             var applicationModel = new ApplicationModel();
             var pagesAppRegistrationModel = await appRegistryDataService.GetAppRegistrationModel(appRegistryPathNameForPagesApp).ConfigureAwait(false);
-         
+
             if (pagesAppRegistrationModel?.PageLocations != null && pagesAppRegistrationModel.IsOnline && pagesAppRegistrationModel.PageLocations.Values.SelectMany(s => s.Locations).Contains("/" + article))
             {
                 applicationModel.AppRegistrationModel = pagesAppRegistrationModel;

--- a/DFC.Composite.Shell.UnitTests/Controllers/ErrorControllerTests.cs
+++ b/DFC.Composite.Shell.UnitTests/Controllers/ErrorControllerTests.cs
@@ -27,7 +27,6 @@ namespace DFC.Composite.Shell.Test.Controllers
         public void ErrorControllerErrorActionReturnsSuccess()
         {
             // Arrange
-            string expectedUrl = $"/{ApplicationController.AlertPathName}/500";
             using var errorController = new ErrorController(fakeLogger, fakeVersionedFiles, fakeConfiguration)
             {
                 ControllerContext = new ControllerContext()

--- a/DFC.Composite.Shell.UnitTests/Controllers/SitemapControllerTests.cs
+++ b/DFC.Composite.Shell.UnitTests/Controllers/SitemapControllerTests.cs
@@ -24,7 +24,6 @@ namespace DFC.Composite.Shell.Test.Controllers
     {
         private const string DummyScheme = "dummyScheme";
         private const string DummyHost = "dummyHost";
-        private const string DummyHomeIndex = "/DummyHomeIndex";
 
         private readonly SitemapController defaultController;
         private readonly ILogger<SitemapController> defaultLogger;
@@ -65,7 +64,6 @@ namespace DFC.Composite.Shell.Test.Controllers
             A.CallTo(() => defaultHttpContext.User).Returns(principal);
 
             defaultUrlHelper = A.Fake<IUrlHelper>();
-            A.CallTo(() => defaultUrlHelper.Action(A<UrlActionContext>.Ignored)).Returns(DummyHomeIndex);
 
             defaultTokenRetriever = A.Fake<IBearerTokenRetriever>();
             A.CallTo(() => defaultTokenRetriever.GetToken(A<HttpContext>.Ignored)).Returns("SomeToken");
@@ -98,14 +96,6 @@ namespace DFC.Composite.Shell.Test.Controllers
             var result = await defaultController.Sitemap().ConfigureAwait(false);
 
             Assert.True(!string.IsNullOrWhiteSpace(result.Content) && result.ContentType == MediaTypeNames.Application.Xml);
-        }
-
-        [Fact]
-        public async Task SitemapControllerWritesShellSitemapPathsText()
-        {
-            var result = await defaultController.Sitemap().ConfigureAwait(false);
-
-            Assert.Contains(DummyHomeIndex, result.Content, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]

--- a/DFC.Composite.Shell.UnitTests/LogHandler/FakeLogger.cs
+++ b/DFC.Composite.Shell.UnitTests/LogHandler/FakeLogger.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+
+namespace DFC.Composite.Shell.UnitTests.LogHandler
+{
+    public abstract class FakeLogger<T> : ILogger<T>
+    {
+        public IDisposable BeginScope<TState>(TState state)
+            => throw new NotImplementedException();
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            => Log(logLevel, exception, formatter(state, exception));
+
+        public abstract void Log(LogLevel logLevel, Exception ex, string information);
+    }
+}

--- a/DFC.Composite.Shell.Views.UnitTests/Tests/ShowHelpLinksViewComponentTests.cs
+++ b/DFC.Composite.Shell.Views.UnitTests/Tests/ShowHelpLinksViewComponentTests.cs
@@ -1,10 +1,4 @@
-﻿using DFC.Composite.Shell.Models.AppRegistrationModels;
-using DFC.Composite.Shell.Services.AppRegistry;
-using DFC.Composite.Shell.ViewComponents;
-using DFC.Composite.Shell.Views.Test.Extensions;
-using Microsoft.Extensions.Logging;
-using Moq;
-using System.Threading.Tasks;
+﻿using DFC.Composite.Shell.ViewComponents;
 using Xunit;
 
 namespace DFC.Composite.Shell.Views.Test.Tests
@@ -12,41 +6,18 @@ namespace DFC.Composite.Shell.Views.Test.Tests
     public class ShowHelpLinksViewComponentTests
     {
         private readonly ShowHelpLinksViewComponent viewComponent;
-        private readonly Mock<ILogger<ShowHelpLinksViewComponent>> logger;
-        private readonly Mock<IAppRegistryDataService> appRegistryDataService;
 
         public ShowHelpLinksViewComponentTests()
         {
-            logger = new Mock<ILogger<ShowHelpLinksViewComponent>>();
-            appRegistryDataService = new Mock<IAppRegistryDataService>();
-
-            viewComponent = new ShowHelpLinksViewComponent(logger.Object, appRegistryDataService.Object);
+            viewComponent = new ShowHelpLinksViewComponent();
         }
 
         [Fact]
-        public async Task ReturnsPathModelDetailsWhenPathExists()
+        public void ReturnsPathModelDetailsWhenPathExists()
         {
-            var appRegistrationModel = new AppRegistrationModel() { IsOnline = true, OfflineHtml = "OfflineHtml" };
-            appRegistryDataService.Setup(x => x.GetAppRegistrationModel(It.IsAny<string>())).ReturnsAsync(appRegistrationModel);
+            var result = viewComponent.Invoke();
 
-            var result = await viewComponent.InvokeAsync();
-
-            var viewComponentModel = result.ViewDataModelAs<ShowHelpLinksViewModel>();
-            Assert.Equal(appRegistrationModel.IsOnline, viewComponentModel.IsOnline);
-            Assert.Equal(appRegistrationModel.OfflineHtml, viewComponentModel.OfflineHtml.Value);
-        }
-
-        [Fact]
-        public async Task ReturnsOfflineFalseWhenPathDoesNotExist()
-        {
-            var appRegistrationModel = new AppRegistrationModel() { IsOnline = false };
-            appRegistryDataService.Setup(x => x.GetAppRegistrationModel(It.IsAny<string>())).ReturnsAsync(appRegistrationModel);
-
-            var result = await viewComponent.InvokeAsync();
-
-            var viewComponentModel = result.ViewDataModelAs<ShowHelpLinksViewModel>();
-            Assert.Equal(appRegistrationModel.IsOnline, viewComponentModel.IsOnline);
-            Assert.Equal(appRegistrationModel.OfflineHtml, viewComponentModel.OfflineHtml.Value);
+            Assert.NotNull(result);
         }
     }
 }

--- a/DFC.Composite.Shell/ClientHandlers/CookieDelegatingHandler.cs
+++ b/DFC.Composite.Shell/ClientHandlers/CookieDelegatingHandler.cs
@@ -33,6 +33,11 @@ namespace DFC.Composite.Shell.ClientHandlers
         {
             var prefix = pathLocator.GetPath();
 
+            if (string.IsNullOrWhiteSpace(prefix))
+            {
+                prefix = "pages";
+            }
+
             CopyHeaders(prefix, httpContextAccessor.HttpContext.Request.Headers, request?.Headers);
             CopyHeaders(prefix, httpContextAccessor.HttpContext.Items, request?.Headers);
             AddTokenHeaderFromCookie(httpContextAccessor.HttpContext, request);

--- a/DFC.Composite.Shell/Controllers/ApplicationController.cs
+++ b/DFC.Composite.Shell/Controllers/ApplicationController.cs
@@ -79,7 +79,7 @@ namespace DFC.Composite.Shell.Controllers
                 {
                     try
                     {
-                        logger.LogInformation($"{nameof(Action)}: Getting child response for: {requestItem.Path}");
+                        logger.LogInformation($"{nameof(Action)}: Getting child response for: {requestItem.Path}/{requestItem.Data}");
 
                         await neo4JService.InsertNewRequest(Request).ConfigureAwait(false);
 
@@ -95,7 +95,7 @@ namespace DFC.Composite.Shell.Controllers
                         }
                         else if (application.AppRegistrationModel.ExternalURL != null)
                         {
-                            logger.LogInformation($"{nameof(Action)}: Redirecting to external for: {requestItem.Path}");
+                            logger.LogInformation($"{nameof(Action)}: Redirecting to external for: {requestItem.Path}/{requestItem.Data}");
 
                             return Redirect(application.AppRegistrationModel.ExternalURL.ToString());
                         }
@@ -107,7 +107,7 @@ namespace DFC.Composite.Shell.Controllers
 
                             await applicationService.GetMarkupAsync(application, application.Article, viewModel, Request.QueryString.Value).ConfigureAwait(false);
 
-                            logger.LogInformation($"{nameof(Action)}: Received child response for: {requestItem.Path}");
+                            logger.LogInformation($"{nameof(Action)}: Received child response for: {requestItem.Path}/{requestItem.Data}");
 
                             if (string.Compare(requestItem.Path, AlertPathName, true, CultureInfo.InvariantCulture) == 0 && int.TryParse(requestItem.Data, out var statusCode))
                             {
@@ -172,7 +172,7 @@ namespace DFC.Composite.Shell.Controllers
                 {
                     try
                     {
-                        logger.LogInformation($"{nameof(Action)}: Getting child response for: {requestItem.Path}");
+                        logger.LogInformation($"{nameof(Action)}: Getting child response for: {requestItem.Path}/{requestItem.Data}");
 
                         var application = await applicationService.GetApplicationAsync(requestItem.Path, requestItem.Data).ConfigureAwait(false);
 
@@ -208,7 +208,7 @@ namespace DFC.Composite.Shell.Controllers
                                 await applicationService.GetMarkupAsync(application, requestItem.Data, viewModel, string.Empty).ConfigureAwait(false);
                             }
 
-                            logger.LogInformation($"{nameof(Action)}: Received child response for: {requestItem.Path}");
+                            logger.LogInformation($"{nameof(Action)}: Received child response for: {requestItem.Path}/{requestItem.Data}");
 
                             if (string.Compare(requestItem.Path, AlertPathName, true, CultureInfo.InvariantCulture) == 0)
                             {

--- a/DFC.Composite.Shell/Controllers/SitemapController.cs
+++ b/DFC.Composite.Shell/Controllers/SitemapController.cs
@@ -41,7 +41,7 @@ namespace DFC.Composite.Shell.Controllers
         {
             logger.LogInformation("Generating Sitemap.xml");
 
-            var sitemap = AppendShellSitemap();
+            var sitemap = new Sitemap();
 
             // get all the registered application site maps
             var applicationSitemapModels = await GetApplicationSitemapsAsync().ConfigureAwait(false);
@@ -52,17 +52,6 @@ namespace DFC.Composite.Shell.Controllers
             logger.LogInformation("Generated Sitemap.xml");
 
             return Content(xmlString, MediaTypeNames.Application.Xml);
-        }
-
-        private Sitemap AppendShellSitemap()
-        {
-            const string homeControllerName = "Home";
-            var sitemap = new Sitemap();
-
-            // output the composite UI site maps
-            sitemap.Add(new SitemapLocation { Url = Url.Action(nameof(HomeController.Index), homeControllerName, null, Request.Scheme) });
-
-            return sitemap;
         }
 
         private async Task<IEnumerable<ApplicationSitemapModel>> GetApplicationSitemapsAsync()

--- a/DFC.Composite.Shell/Startup.cs
+++ b/DFC.Composite.Shell/Startup.cs
@@ -249,7 +249,7 @@ namespace DFC.Composite.Shell
                 endpoints.MapRazorPages();
 
                 // add the default route
-                endpoints.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
+                endpoints.MapControllerRoute("default", "{controller=Application}/{action=Action}/");
 
                 // add the site map route
                 endpoints.MapControllerRoute("Sitemap", "Sitemap.xml", new { controller = "Sitemap", action = "Sitemap" });

--- a/DFC.Composite.Shell/ViewComponents/ShowHelpLinksViewComponent.cs
+++ b/DFC.Composite.Shell/ViewComponents/ShowHelpLinksViewComponent.cs
@@ -1,47 +1,12 @@
-﻿using DFC.Composite.Shell.Services.AppRegistry;
-using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-using Polly.CircuitBreaker;
-using System.Threading.Tasks;
+﻿using Microsoft.AspNetCore.Mvc;
 
 namespace DFC.Composite.Shell.ViewComponents
 {
     public class ShowHelpLinksViewComponent : ViewComponent
     {
-        private readonly ILogger<ShowHelpLinksViewComponent> logger;
-        private readonly IAppRegistryDataService appRegistryDataService;
-
-        public ShowHelpLinksViewComponent(ILogger<ShowHelpLinksViewComponent> logger, IAppRegistryDataService appRegistryDataService)
+        public IViewComponentResult Invoke()
         {
-            this.logger = logger;
-            this.appRegistryDataService = appRegistryDataService;
-        }
-
-        public async Task<IViewComponentResult> InvokeAsync()
-        {
-            var vm = new ShowHelpLinksViewModel { IsOnline = false };
-
-            try
-            {
-                var helpPath = await appRegistryDataService.GetAppRegistrationModel("help").ConfigureAwait(false);
-
-                if (helpPath != null)
-                {
-                    vm.IsOnline = helpPath.IsOnline;
-                    vm.OfflineHtml = new HtmlString(helpPath.OfflineHtml);
-                }
-            }
-            catch (BrokenCircuitException ex)
-            {
-                var errorString = $"{nameof(ShowHelpLinksViewComponent)}: BrokenCircuit: {ex.Message}";
-
-                logger.LogError(ex, errorString);
-
-                throw;
-            }
-
-            return View(vm);
+            return View();
         }
     }
 }

--- a/DFC.Composite.Shell/Views/Shared/Components/ShowHelpLinks/Default.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/Components/ShowHelpLinks/Default.cshtml
@@ -1,16 +1,3 @@
-﻿@model DFC.Composite.Shell.ViewComponents.ShowHelpLinksViewModel
-
-@{
-    if (Model.IsOnline)
-    {
-        <ul class="govuk-footer__inline-list" aria-label="Footer Links">
-            <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/help">Help</a></li><li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/help/cookies">Privacy and cookies</a></li><li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/help/accessibility">Accessibility statement</a></li><li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/help/terms-and-conditions">Terms and conditions</a></li><li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/help/information-sources">Information sources</a></li>
-        </ul>
-    }
-    else
-    {
-        <div class="govuk-footer__meta-item">
-            @Html.Raw(Model.OfflineHtml)
-        </div>
-    }
-}
+﻿<ul class="govuk-footer__inline-list" aria-label="Footer Links">
+    <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/help">Help</a></li><li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/help/cookies">Privacy and cookies</a></li><li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/help/accessibility">Accessibility statement</a></li><li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/help/terms-and-conditions">Terms and conditions</a></li><li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/help/information-sources">Information sources</a></li>
+</ul>

--- a/DFC.Composite.Shell/Views/Shared/_ErrorSummary.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_ErrorSummary.cshtml
@@ -3,8 +3,8 @@
 }
 
 <div class="govuk-width-container">
-    <div id="compuiShell-ErrorSummary" class="govuk-error-summary @showHideErrorSummary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
+    <div id="compuiShell-ErrorSummary" class="govuk-error-summary @showHideErrorSummary" aria-labelledby="compuiShell-error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+        <h2 class="govuk-error-summary__title" id="compuiShell-error-summary-title">
             There is a problem
         </h2>
         <div class="govuk-error-summary__body">

--- a/DFC.Composite.Shell/Views/Shared/_LayoutFullWidth.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_LayoutFullWidth.cshtml
@@ -1,80 +1,77 @@
-﻿<!DOCTYPE html>
-<html lang="en-gb" class="govuk-template ">
+﻿    <!DOCTYPE html>
+    <html lang="en-gb" class="govuk-template ">
 
-<head>
-    <partial name="_Head" />
+    <head>
+        <partial name="_Head"/>
 
-    @if (IsSectionDefined("Head"))
-    {
-        @RenderSection("Head", required: false)
-    }
-
-    @await Component.InvokeAsync("AppInsights", null)
-</head>
-
-<body class="govuk-template__body ">
-    <partial name="_GovUkHeader" />
-
-    <div class="govuk-width-container">
-
-        <partial name="_PhaseBanner" />
-
-        <partial name="_ErrorSummary" />
-
-        <partial name="~/Views/Shared/Components/_AuthPartial.cshtml" />
-    </div>
-    @if (IsSectionDefined("BodyTop"))
-    {
-        @RenderSection("BodyTop", required: false)
-    }
-
-
-    @if (IsSectionDefined("HeroBanner"))
-    {
-        @RenderSection("HeroBanner", required: false)
-    }
-
-    <div class="govuk-width-container">
-        <main class="govuk-main-wrapper" id="main-content" role="main">
-
-            @if (IsSectionDefined("Breadcrumb"))
-            {
-                @RenderSection("Breadcrumb", required: false)
-            }
-
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-full">
-                    @if (IsSectionDefined("Body"))
-                    {
-                        @RenderSection("Body", required: false)
-                    }
-                </div>
-            </div>
-
-            @RenderBody()
-
-            @{
-                if (IsSectionDefined("SideBarLeft"))
-                {
-                    IgnoreSection("SideBarLeft");
-                }
-                if (IsSectionDefined("SideBarRight"))
-                {
-                    IgnoreSection("SideBarRight");
-                }
-            }
-        </main>
-
-        @if (IsSectionDefined("BodyFooter"))
+        @if (IsSectionDefined("Head"))
         {
-            @RenderSection("BodyFooter", required: false)
+            @RenderSection("Head", required: false)
         }
+
+        @await Component.InvokeAsync("AppInsights", null)
+    </head>
+
+    <body class="govuk-template__body ">
+    <partial name="_GovUkHeader"/>
+    
+    <div class="govuk-width-container">
+        <partial name="_PhaseBanner"/>
+        <partial name="~/Views/Shared/Components/_AuthPartial.cshtml"/>
+        @if (IsSectionDefined("Breadcrumb"))
+        {
+            @RenderSection("Breadcrumb", required: false)
+        }
+        <partial name="_ErrorSummary"/>
     </div>
 
-    <partial name="_GovUkFooter" />
+    <main class="govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content" role="main">
+        @if (IsSectionDefined("BodyTop"))
+        {
+            @RenderSection("BodyTop", required: false)
+        }
 
-    <partial name="_JQueryInitialise" />
+
+        @if (IsSectionDefined("HeroBanner"))
+        {
+            @RenderSection("HeroBanner", required: false)
+        }
+        <div class="govuk-main-wrapper">
+            <div class="govuk-width-container">
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full">
+                        @if (IsSectionDefined("Body"))
+                        {
+                            @RenderSection("Body", required: false)
+                        }
+                    </div>
+                </div>
+
+                @RenderBody()
+
+                @{
+                    if (IsSectionDefined("SideBarLeft"))
+                    {
+                        IgnoreSection("SideBarLeft");
+                    }
+                    if (IsSectionDefined("SideBarRight"))
+                    {
+                        IgnoreSection("SideBarRight");
+                    }
+                }
+            </div>
+        </div>
+    </main>
+
+    @if (IsSectionDefined("BodyFooter"))
+    {
+        @RenderSection("BodyFooter", required: false)
+    }
+
+    <partial name="_GovUkFooter"/>
+
+    <partial name="_JQueryInitialise"/>
 
     @RenderSection("Scripts", required: false)
-</body>
-</html>
+    </body>
+    </html>

--- a/DFC.Composite.Shell/Views/Shared/_LayoutSidebarLeft.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_LayoutSidebarLeft.cshtml
@@ -1,89 +1,84 @@
-﻿<!DOCTYPE html>
-<html lang="en-gb" class="govuk-template ">
+﻿    <!DOCTYPE html>
+    <html lang="en-gb" class="govuk-template ">
 
-<head>
-    <partial name="_Head" />
+    <head>
+        <partial name="_Head"/>
 
-    @if (IsSectionDefined("Head"))
-    {
-        @RenderSection("Head", required: false)
-    }
-
-    @await Component.InvokeAsync("AppInsights", null)
-</head>
-
-<body class="govuk-template__body ">
-    <partial name="_GovUkHeader" />
-
-    <div class="govuk-width-container">
-
-        <partial name="_PhaseBanner" />
-
-        <partial name="_ErrorSummary" />
-
-        <partial name="~/Views/Shared/Components/_AuthPartial.cshtml" />
-
-    </div>
-
-    @if (IsSectionDefined("BodyTop"))
-    {
-        @RenderSection("BodyTop", required: false)
-    }
-
-
-    @if (IsSectionDefined("HeroBanner"))
-    {
-        @RenderSection("HeroBanner", required: false)
-    }
-
-    <div class="govuk-width-container">
-        <main class="govuk-main-wrapper" id="main-content" role="main">
-
-            @if (IsSectionDefined("Breadcrumb"))
-            {
-                @RenderSection("Breadcrumb", required: false)
-            }
-
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-one-third">
-                    @if (IsSectionDefined("SideBarLeft"))
-                    {
-                        <div>
-                            @RenderSection("SideBarLeft", required: false)
-                        </div>
-                    }
-                </div>
-
-                <div class="govuk-grid-column-two-thirds">
-                    @if (IsSectionDefined("Body"))
-                    {
-                        <div>
-                            @RenderSection("Body", required: false)
-                        </div>
-                    }
-                </div>
-            </div>
-
-            @RenderBody()
-
-            @{
-                if (IsSectionDefined("SideBarRight"))
-                {
-                    IgnoreSection("SideBarRight");
-                }
-            }
-        </main>
-
-        @if (IsSectionDefined("BodyFooter"))
+        @if (IsSectionDefined("Head"))
         {
-            @RenderSection("BodyFooter", required: false)
+            @RenderSection("Head", required: false)
         }
+
+        @await Component.InvokeAsync("AppInsights", null)
+    </head>
+
+    <body class="govuk-template__body ">
+    <partial name="_GovUkHeader"/>
+    
+    <div class="govuk-width-container">
+        <partial name="_PhaseBanner"/>
+        <partial name="~/Views/Shared/Components/_AuthPartial.cshtml"/>
+        @if (IsSectionDefined("Breadcrumb"))
+        {
+            @RenderSection("Breadcrumb", required: false)
+        }
+        <partial name="_ErrorSummary"/>
     </div>
 
-    <partial name="_GovUkFooter" />
+    <main class="govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content" role="main">
+        @if (IsSectionDefined("BodyTop"))
+        {
+            @RenderSection("BodyTop", required: false)
+        }
 
-    <partial name="_JQueryInitialise" />
+
+        @if (IsSectionDefined("HeroBanner"))
+        {
+            @RenderSection("HeroBanner", required: false)
+        }
+        <div class="govuk-main-wrapper">
+            <div class="govuk-width-container">
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-one-third">
+                        @if (IsSectionDefined("SideBarLeft"))
+                        {
+                            <div>
+                                @RenderSection("SideBarLeft", required: false)
+                            </div>
+                        }
+                    </div>
+
+                    <div class="govuk-grid-column-two-thirds">
+                        @if (IsSectionDefined("Body"))
+                        {
+                            <div>
+                                @RenderSection("Body", required: false)
+                            </div>
+                        }
+                    </div>
+                </div>
+
+                @RenderBody()
+
+                @{
+                    if (IsSectionDefined("SideBarRight"))
+                    {
+                        IgnoreSection("SideBarRight");
+                    }
+                }
+            </div>
+        </div>
+    </main>
+
+    @if (IsSectionDefined("BodyFooter"))
+    {
+        @RenderSection("BodyFooter", required: false)
+    }
+    
+    <partial name="_GovUkFooter"/>
+
+    <partial name="_JQueryInitialise"/>
 
     @RenderSection("Scripts", required: false)
-</body>
-</html>
+    </body>
+    </html>

--- a/DFC.Composite.Shell/Views/Shared/_LayoutSidebarRight.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_LayoutSidebarRight.cshtml
@@ -1,89 +1,85 @@
-﻿<!DOCTYPE html>
-<html lang="en-gb" class="govuk-template ">
+﻿    <!DOCTYPE html>
+    <html lang="en-gb" class="govuk-template ">
 
-<head>
-    <partial name="_Head" />
+    <head>
+        <partial name="_Head"/>
 
-    @if (IsSectionDefined("Head"))
-    {
-        @RenderSection("Head", required: false)
-    }
-
-    @await Component.InvokeAsync("AppInsights", null)
-</head>
-
-<body class="govuk-template__body ">
-    <partial name="_GovUkHeader" />
-
-    <div class="govuk-width-container">
-
-        <partial name="_PhaseBanner" />
-
-        <partial name="_ErrorSummary" />
-
-        <partial name="~/Views/Shared/Components/_AuthPartial.cshtml" />
-
-    </div>
-
-    @if (IsSectionDefined("BodyTop"))
-    {
-        @RenderSection("BodyTop", required: false)
-    }
-
-
-    @if (IsSectionDefined("HeroBanner"))
-    {
-        @RenderSection("HeroBanner", required: false)
-    }
-
-    <div class="govuk-width-container">
-        <main class="govuk-main-wrapper" id="main-content" role="main">
-
-            @if (IsSectionDefined("Breadcrumb"))
-            {
-                @RenderSection("Breadcrumb", required: false)
-            }
-
-            <div class="govuk-grid-row">
-                <div class="govuk-grid-column-two-thirds">
-                    @if (IsSectionDefined("Body"))
-                    {
-                        <div>
-                            @RenderSection("Body", required: false)
-                        </div>
-                    }
-                </div>
-
-                <div class="govuk-grid-column-one-third">
-                    @if (IsSectionDefined("SideBarRight"))
-                    {
-                        <div>
-                            @RenderSection("SideBarRight", required: false)
-                        </div>
-                    }
-                </div>
-            </div>
-
-            @RenderBody()
-
-            @{
-                if (IsSectionDefined("SideBarLeft"))
-                {
-                    IgnoreSection("SideBarLeft");
-                }
-            }
-        </main>
-
-        @if (IsSectionDefined("BodyFooter"))
+        @if (IsSectionDefined("Head"))
         {
-            @RenderSection("BodyFooter", required: false)
+            @RenderSection("Head", required: false)
         }
+
+        @await Component.InvokeAsync("AppInsights", null)
+    </head>
+
+    <body class="govuk-template__body ">
+    <partial name="_GovUkHeader"/>
+
+    <div class="govuk-width-container">
+        <partial name="_PhaseBanner"/>
+        <partial name="~/Views/Shared/Components/_AuthPartial.cshtml"/>
+        @if (IsSectionDefined("Breadcrumb"))
+        {
+            @RenderSection("Breadcrumb", required: false)
+        }
+        <partial name="_ErrorSummary"/>
     </div>
 
-    <partial name="_GovUkFooter" />
+    <main class="govuk-!-padding-top-0 govuk-!-padding-bottom-0" id="main-content" role="main">
+        @if (IsSectionDefined("BodyTop"))
+        {
+            @RenderSection("BodyTop", required: false)
+        }
 
-    <partial name="_JQueryInitialise" />
+
+        @if (IsSectionDefined("HeroBanner"))
+        {
+            @RenderSection("HeroBanner", required: false)
+        }
+        <div class="govuk-main-wrapper">
+            <div class="govuk-width-container">
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-two-thirds">
+                        @if (IsSectionDefined("Body"))
+                        {
+                            <div>
+                                @RenderSection("Body", required: false)
+                            </div>
+                        }
+                    </div>
+
+                    <div class="govuk-grid-column-one-third">
+                        @if (IsSectionDefined("SideBarRight"))
+                        {
+                            <div>
+                                @RenderSection("SideBarRight", required: false)
+                            </div>
+                        }
+                    </div>
+                </div>
+
+                @RenderBody()
+
+                @{
+                    if (IsSectionDefined("SideBarLeft"))
+                    {
+                        IgnoreSection("SideBarLeft");
+                    }
+                }
+            </div>
+        </div>
+    </main>
+
+    @if (IsSectionDefined("BodyFooter"))
+    {
+        @RenderSection("BodyFooter", required: false)
+    }
+
+
+    <partial name="_GovUkFooter"/>
+
+    <partial name="_JQueryInitialise"/>
 
     @RenderSection("Scripts", required: false)
-</body>
-</html>
+    </body>
+    </html>

--- a/DFC.Composite.Shell/appsettings-template.json
+++ b/DFC.Composite.Shell/appsettings-template.json
@@ -26,7 +26,7 @@
   "AppRegistryClientOptions": {
     "Timeout": "00:00:30",
     "ApiKey": "[APIM key]",
-    "BaseAddress": "http://localhost:7071/"
+    "BaseAddress": "http://localhost:7073/appregistry/"
   },
   "ApplicationClientOptions": {
     "Timeout": "00:00:30",

--- a/PageRegistration/registration.json
+++ b/PageRegistration/registration.json
@@ -30,7 +30,8 @@
     "Layout": 0,
     "OfflineHtml": "<div class=\"govuk-width-container\"><H2>External App is Unavailable</H2></div>",
     "ExternalUrl": "__ExternalLiveSite__/contact-us"
-  },{
+  },
+  {
     "Path": "about-us",
     "TopNavigationText": "About us",
     "TopNavigationOrder": 800,

--- a/Resources/ArmTemplates/parameters.json
+++ b/Resources/ArmTemplates/parameters.json
@@ -44,6 +44,21 @@
         "SharedAppServicePlanResourceGroup": {
             "value": "__CompositeUiSharedResourceGroup__"
         },
+        "EnvironmentName": {
+            "value": "__EnvironmentNameAppSetting__"
+        },
+        "customHostName": {
+            "value": "__customHostName__"
+        },
+        "keyVaultName": {
+            "value": "__SharedKeyVaultName__"
+        },
+        "keyVaultResourceGroup": {
+            "value": "__SharedResourceGroup__"
+        },
+        "certificateName": {
+            "value": "__certificateName__"
+        },
         "enableAlerts": {
             "value": __EnableAzureMonitorAlerting__
         },
@@ -74,8 +89,11 @@
         "Neo4JSettingsSendData": {
             "value": __Neo4JSettingsSendData__
         },
-        "ExceptionCountThreshold":{
+        "ExceptionCountThreshold": {
             "value": "__ExceptionCountThreshold__"
+        },
+        "AppRegistryClientOptionsBaseAddress": {
+            "value": "__AppRegistryClientOptionsBaseAddress__"
         }
     }
 }

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -47,6 +47,21 @@
             "type": "string",
             "defaultValue": ""
         },
+        "customHostName": {
+            "type": "string"
+        },
+        "keyVaultName": {
+            "type": "string"
+        },
+        "keyVaultResourceGroup": {
+            "type": "string"
+        },
+        "certificateName": {
+            "type": "string"
+        },
+        "EnvironmentName": {
+            "type": "string"
+        },
         "enableAlerts": {
             "type": "bool",
             "metadata": {
@@ -81,6 +96,9 @@
             "type": "bool"
         },
         "ExceptionCountThreshold": {
+            "type": "string"
+        },
+        "AppRegistryClientOptionsBaseAddress": {
             "type": "string"
         }
     },
@@ -152,6 +170,33 @@
             }
         },
         {
+            "name": "compositeshellCertificates",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2017-05-10",
+            "condition": "[greater(length(parameters('customHostName')),0)]",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'),'certificate.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "keyVaultName": {
+                        "value": "[parameters('keyVaultName')]"
+                    },
+                    "keyVaultCertificateName": {
+                        "value": "[parameters('certificateName')]"
+                    },
+                    "keyVaultResourceGroup": {
+                        "value": "[parameters('keyVaultResourceGroup')]"
+                    },
+                    "serverFarmId": {
+                        "value": "[resourceId(parameters('SharedAppServicePlanResourceGroup'),'Microsoft.Web/serverfarms', parameters('SharedAppServicePlanName'))]"
+                    }
+                }
+            }
+        },
+        {
             "apiVersion": "2017-05-10",
             "name": "[variables('WebAppName')]",
             "type": "Microsoft.Resources/deployments",
@@ -174,6 +219,12 @@
                     "appServiceType": {
                         "value": "app"
                     },
+                    "customHostName": {
+                        "value": "[parameters('customHostName')]"
+                    },
+                    "certificateThumbprint": {
+                        "value": "[if(greater(length(parameters('customHostName')),0), reference('compositeshellCertificates').outputs.certificateThumbprint.value, '')]"
+                    },
                     "appServiceAppSettings": {
                         "value": [
                             {
@@ -183,6 +234,10 @@
                             {
                                 "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
                                 "value": "[reference(variables('AppServiceAppInsightsName')).outputs.InstrumentationKey.value]"
+                            },
+                            {
+                                "name": "EnvironmentSettings__EnvironmentName",
+                                "value": "[parameters('environmentName')]"
                             },
                             {
                                 "name": "ApplicationInsights__ScriptResourceAddress",
@@ -350,7 +405,7 @@
                             },
                             {
                                 "name": "AppRegistryClientOptions__BaseAddress",
-                                "value": "[concat(parameters('ApimProxyAddress'), '/composite-ui-appRegistry/appregistry/')]"
+                                "value": "[parameters('AppRegistryClientOptionsBaseAddress')]"
                             },
                             {
                                 "name": "AppRegistryClientOptions__ApiKey",
@@ -380,51 +435,51 @@
                 "[variables('AppServiceAppInsightsName')]"
             ],
             "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/metric-alerts.json')]",
-                    "contentVersion": "1.0.0.0"
+            "mode": "Incremental",
+            "templateLink": {
+                "uri": "[concat(variables('BuildingBlocksDfcBaseUrl'), 'Application-Insights/metric-alerts.json')]",
+                "contentVersion": "1.0.0.0"
+            },
+            "parameters": {
+                "enabled": {
+                    "value": "[parameters('enableAlerts')]"
                 },
-                "parameters": {
-                    "enabled": {
-                        "value": "[parameters('enableAlerts')]"
-                    },
-                    "alertName": {
-                        "value": "[concat(variables('AppServiceAppInsightsName'), '-metric-exceptions')]"
-                    },
-                    "alertSeverity": {
-                        "value": 3
-                    },
-                    "metricName": {
-                        "value": "exceptions/count"
-                    },
-                    "operator": {
-                        "value": "GreaterThan"
-                    },
-                    "threshold": {
-                        "value": "[parameters('ExceptionCountThreshold')]"
-                    },
-                    "aggregation": {
-                        "value": "Count"
-                    },
-                    "windowSize": {
-                        "value": "PT5M"
-                    },
-                    "evaluationFrequency": {
-                        "value": "PT1M"
-                    },
-                    "actionGroupName": {
-                        "value": "[variables('ActionGroupName')]"
-                    },
-                    "actionGroupResourceGroup": {
-                        "value": "[parameters('CompositeUiSharedResourceGroup')]"
-                    },
-                    "resourceId": {
-                        "value": "[resourceId('Microsoft.Insights/Components', variables('AppServiceAppInsightsName'))]"
-                    }
+                "alertName": {
+                    "value": "[concat(variables('AppServiceAppInsightsName'), '-metric-exceptions')]"
+                },
+                "alertSeverity": {
+                    "value": 3
+                },
+                "metricName": {
+                    "value": "exceptions/count"
+                },
+                "operator": {
+                    "value": "GreaterThan"
+                },
+                "threshold": {
+                    "value": "[parameters('ExceptionCountThreshold')]"
+                },
+                "aggregation": {
+                    "value": "Count"
+                },
+                "windowSize": {
+                    "value": "PT5M"
+                },
+                "evaluationFrequency": {
+                    "value": "PT1M"
+                },
+                "actionGroupName": {
+                    "value": "[variables('ActionGroupName')]"
+                },
+                "actionGroupResourceGroup": {
+                    "value": "[parameters('CompositeUiSharedResourceGroup')]"
+                },
+                "resourceId": {
+                    "value": "[resourceId('Microsoft.Insights/Components', variables('AppServiceAppInsightsName'))]"
                 }
             }
-        },
+        }
+        }, 
         {
             "apiVersion": "2019-05-01",
             "name": "[concat(variables('AppServiceAppInsightsName'), '-failure-anomaly-v2')]",
@@ -454,7 +509,7 @@
                 }
             }
         }
-    ],
+    ], 
     "outputs": {
-    }
+    } 
 }

--- a/Resources/ArmTemplates/test-parameters.json
+++ b/Resources/ArmTemplates/test-parameters.json
@@ -29,6 +29,21 @@
         "SharedAppServicePlanResourceGroup": {
             "value": "dfc-dev-compui-shared-rg"
         },
+        "EnvironmentName": {
+            "value": "Development"
+        },
+        "customHostName": {
+            "value": "some.host.name"
+        },
+        "keyVaultName": {
+            "value": "a-keyvault"
+        },
+        "keyVaultResourceGroup": {
+            "value": "keyvault-rg"
+        },
+        "certificateName": {
+            "value": "certificate-name"
+        },
         "enableAlerts": {
             "value": false
         },
@@ -59,8 +74,11 @@
         "Neo4JSettingsSendData": {
             "value": false
         },
-        "ExceptionCountThreshold":{
+        "ExceptionCountThreshold": {
             "value": "0"
+        },
+        "AppRegistryClientOptionsBaseAddress": {
+            "value": "dummyurl"
         }
     }
 }


### PR DESCRIPTION
### This release includes the following changes.
- Moved breadcrumb (with phase banner, sign in and error summary) outside of the MAIN section (#239)
- Changed the adding of responses headers to not throw exceptions if they are already there. (#236)
- Removed the trailing slash for the page location search (#237)
- Ncsd 4319 add custom host domain dev sit (#230)
- Changed to use the TryAddWithoutValidation when adding the useragent header. (#233)
- allowed visit request to fail silently (#232)
- Updated DFC.Compui.Telemetry to use version 1.0.29 so that only one operationId header can be added. (#229)
- Bug dfcc 818 remove isonline check arounf help lnks (#228)
- Removed if IsOnline wrapper around help links in the footer (#227)
- Change ID for H2 element due to id name clash (#225)
- Nulled existing help to get a job and added careers advise (#223)
- Changed path for Careers advise back to get-a-job (#222)
- Changed menu from "Help to get a job" to "Careers advise" (#219)
- added env variable as per app insights asp.net core code for app services in azure hosted environments (#220)
- Updated AppRegistryClientOptionsBaseAddress (#217)
- NCSD-4246-parameterise-exception-count (#215)
- re-added find-a-course registration (#213)
- Code tidy and app settings temlate update (#212)
- Bug fixed to prevent too many redirects when unhanded exception caught - now uses interval view instead of redirect /alets/<status-code> (#210)
- Added Neo4jSettingsSendData as pipeline variable as per NCSD-4231 (#208) 
- Removed /Home route to accommodate root pages supplied from pages app (#206)
- Removed Vibrate and Multimedia from Feature-Policy heaader as they are no longer supported(#205)
- Dfcc 430 move elements to main (#204)
- Updated page locations to use a dictionary instead of a list (#203)

Only included some of the changes to keep this note short, look at PR for detailed full list of changes.
