### PR TITLE
Updated cookie settings.

### DIFF
--- a/DFC.Composite.Shell/ClientHandlers/CompositeSessionIdDelegatingHandler.cs
+++ b/DFC.Composite.Shell/ClientHandlers/CompositeSessionIdDelegatingHandler.cs
@@ -1,6 +1,5 @@
 ﻿using DFC.Composite.Shell.Middleware;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,24 +11,15 @@ namespace DFC.Composite.Shell.ClientHandlers
         internal const string HeaderName = "x-dfc-composite-sessionid";
 
         private readonly IHttpContextAccessor httpContextAccessor;
-        private readonly ITempDataDictionaryFactory tempDataDictionaryFactory;
 
-        public CompositeSessionIdDelegatingHandler(IHttpContextAccessor httpContextAccessor, ITempDataDictionaryFactory tempDataDictionaryFactory)
+        public CompositeSessionIdDelegatingHandler(IHttpContextAccessor httpContextAccessor)
         {
             this.httpContextAccessor = httpContextAccessor;
-            this.tempDataDictionaryFactory = tempDataDictionaryFactory;
         }
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var compositeSessionId = httpContextAccessor?.HttpContext?.Request?.Cookies[CompositeSessionIdMiddleware.NcsSessionCookieName];
-
-            if (httpContextAccessor?.HttpContext != null && string.IsNullOrWhiteSpace(compositeSessionId))
-            {
-                var tempData = tempDataDictionaryFactory.GetTempData(httpContextAccessor?.HttpContext);
-
-                compositeSessionId = tempData[HeaderName].ToString();
-            }
 
             if (request != null && !request.Headers.Contains(HeaderName) && !string.IsNullOrWhiteSpace(compositeSessionId))
             {

--- a/DFC.Composite.Shell/Middleware/CompositeSessionIdMiddleware.cs
+++ b/DFC.Composite.Shell/Middleware/CompositeSessionIdMiddleware.cs
@@ -1,6 +1,4 @@
-﻿using DFC.Composite.Shell.ClientHandlers;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
+﻿using Microsoft.AspNetCore.Http;
 using System;
 using System.Threading.Tasks;
 
@@ -17,29 +15,24 @@ namespace DFC.Composite.Shell.Middleware
             this.next = next;
         }
 
-        public async Task Invoke(HttpContext httpContext, ITempDataDictionaryFactory tempDataDictionaryFactory)
+        public async Task Invoke(HttpContext httpContext)
         {
-            string compositeSessionId = httpContext?.Request.Cookies[NcsSessionCookieName];
+            var sessionIdString = httpContext?.Request.Cookies[NcsSessionCookieName];
 
-            if (string.IsNullOrWhiteSpace(compositeSessionId))
+            if (string.IsNullOrWhiteSpace(sessionIdString))
             {
-                compositeSessionId = Guid.NewGuid().ToString();
+                sessionIdString = Guid.NewGuid().ToString();
             }
 
             var cookieOptions = new CookieOptions
             {
                 Expires = DateTime.Now.AddDays(28),
                 Secure = true,
+                HttpOnly = true,
                 SameSite = SameSiteMode.None,
             };
 
-            httpContext?.Response.Cookies.Append(NcsSessionCookieName, compositeSessionId, cookieOptions);
-
-            var tempData = tempDataDictionaryFactory?.GetTempData(httpContext);
-            if (tempData != null)
-            {
-                tempData[CompositeSessionIdDelegatingHandler.HeaderName] = compositeSessionId;
-            }
+            httpContext?.Response.Cookies.Append(NcsSessionCookieName, sessionIdString, cookieOptions);
 
             await next(httpContext).ConfigureAwait(false);
         }


### PR DESCRIPTION
1) Removed use of TempData therefore .AspNetCore.Mvc.CookieTempDataProvider is no longer present in the Shell.
2) Added HttpOnly flag to ncs_session_cookie.