### PR TITLE
Hotfix/dfc 13161 ie comp ui js syntax errors

### DIFF
--- a/DFC.Composite.Shell.Services/Utilities/VersionedFiles.cs
+++ b/DFC.Composite.Shell.Services/Utilities/VersionedFiles.cs
@@ -18,7 +18,6 @@ namespace DFC.Composite.Shell.Utilities
             VersionedPathForJQueryBundleMinJs = assetLocationAndVersionService?.GetCdnAssetFileAndVersion($"{brandingAssetsFolder}/js/jquerybundle.min.js");
             VersionedPathForAllMinJs = assetLocationAndVersionService?.GetCdnAssetFileAndVersion($"{brandingAssetsFolder}/js/all.min.js");
             VersionedPathForDfcDigitalMinJs = assetLocationAndVersionService?.GetCdnAssetFileAndVersion($"{brandingAssetsFolder}/js/dfcdigital.min.js");
-            VersionedPathForCompUiMinJs = assetLocationAndVersionService?.GetCdnAssetFileAndVersion($"{brandingAssetsFolder}/js/compui.min.js");
         }
 
         public string VersionedPathForMainMinCss { get; }

--- a/DFC.Composite.Shell/Startup.cs
+++ b/DFC.Composite.Shell/Startup.cs
@@ -109,7 +109,7 @@ namespace DFC.Composite.Shell
                     .CustomSources("https://*.serco.com/"))
                 .ConnectSources(s => s
                     .Self()
-                    .CustomSources($"{Configuration.GetValue<string>(Constants.ApplicationInsightsConnectSources)}", "https://dc.services.visualstudio.com/", Configuration.GetValue<string>(Constants.ApimProxyAddress))));
+                    .CustomSources($"{Configuration.GetValue<string>(Constants.ApplicationInsightsConnectSources)}", "https://dc.services.visualstudio.com/", Configuration.GetValue<string>(Constants.ApimProxyAddress), "https://www.google-analytics.com")));
 
             app.UseXContentTypeOptions();
             app.UseReferrerPolicy(opts => opts.StrictOriginWhenCrossOrigin());

--- a/DFC.Composite.Shell/Startup.cs
+++ b/DFC.Composite.Shell/Startup.cs
@@ -109,7 +109,7 @@ namespace DFC.Composite.Shell
                     .CustomSources("https://*.serco.com/"))
                 .ConnectSources(s => s
                     .Self()
-                    .CustomSources($"{Configuration.GetValue<string>(Constants.ApplicationInsightsConnectSources)}", "https://dc.services.visualstudio.com/", Configuration.GetValue<string>(Constants.ApimProxyAddress), "https://www.google-analytics.com")));
+                    .CustomSources($"{Configuration.GetValue<string>(Constants.ApplicationInsightsConnectSources)}", "https://dc.services.visualstudio.com/", Configuration.GetValue<string>(Constants.ApimProxyAddress), "https://www.google-analytics.com", "https://www.googletagmanager.com")));
 
             app.UseXContentTypeOptions();
             app.UseReferrerPolicy(opts => opts.StrictOriginWhenCrossOrigin());

--- a/DFC.Composite.Shell/Startup.cs
+++ b/DFC.Composite.Shell/Startup.cs
@@ -118,9 +118,9 @@ namespace DFC.Composite.Shell
 
             app.Use(async (context, next) =>
             {
-                context.Response.Headers.Add("Feature-Policy", "sync-xhr 'self'");
-                context.Response.Headers.Add("Expect-CT", "max-age=86400, enforce");
-                context.Response.Headers.Add("X-Permitted-Cross-Domain-Policies", "none");
+                context.Response.Headers["Feature-Policy"] = "sync-xhr 'self'";
+                context.Response.Headers["Expect-CT"] = "max-age=86400, enforce";
+                context.Response.Headers["X-Permitted-Cross-Domain-Policies"] = "none";
                 await next().ConfigureAwait(false);
             });
 

--- a/DFC.Composite.Shell/Views/Shared/_JQueryInitialise.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_JQueryInitialise.cshtml
@@ -7,7 +7,6 @@
     string VersionedPathForJQueryBundleMinJs = ViewData["VersionedPathForJQueryBundleMinJs"].ToString();
     string VersionedPathForAllMinJs = ViewData["VersionedPathForAllMinJs"].ToString();
     string VersionedPathForDfcDigitalMinJs = ViewData["VersionedPathForDfcDigitalMinJs"].ToString();
-    string VersionedPathForCompUiMinJs = ViewData["VersionedPathForCompUiMinJs"].ToString();
 }
 
 <script src="@(VersionedPathForJQueryBundleMinJs)" type="text/javascript" nws-csp-add-nonce="true"></script>
@@ -16,5 +15,3 @@
 <script nws-csp-add-nonce="true">window.GOVUKFrontend.initAll()</script>
 
 <script src="@(VersionedPathForDfcDigitalMinJs)" nws-csp-add-nonce="true"></script>
-
-<script src="@(VersionedPathForCompUiMinJs)" nws-csp-add-nonce="true"></script>


### PR DESCRIPTION
Removed include of compui.js file because it causes Javascript syntax errors in IE11.
It is not used by the current app that are live in the shell.