### PR TITLE
FT2-950 Adding post file download support to shell

### DIFF
--- a/DFC.Composite.Shell.IntegrationTests/Fakes/FakeContentRetriever.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Fakes/FakeContentRetriever.cs
@@ -3,6 +3,7 @@ using DFC.Composite.Shell.Services.ContentRetrieval;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DFC.Composite.Shell.Models;
 using Microsoft.AspNetCore.Http;
 
 namespace DFC.Composite.Shell.IntegrationTests.Fakes
@@ -24,19 +25,22 @@ namespace DFC.Composite.Shell.IntegrationTests.Fakes
                 regionModel?.PageRegion.ToString()));
         }
 
-        public Task<string> PostContent(
+        public Task<PostResponseModel> PostContent(
             string url,
             string path,
             RegionModel regionModel,
             IEnumerable<KeyValuePair<string, string>> formParameters,
             string requestBaseUrl)
         {
-            return Task.FromResult(Concat(
-                "POST",
-                url,
-                path,
-                regionModel?.PageRegion.ToString(),
-                string.Join(", ", formParameters.Select(kvp => string.Concat(kvp.Key, "=", kvp.Value)))));
+            return Task.FromResult(new PostResponseModel
+            {
+                HTML = Concat(
+                    "POST",
+                    url,
+                    path,
+                    regionModel?.PageRegion.ToString(),
+                    string.Join(", ", formParameters.Select(kvp => string.Concat(kvp.Key, "=", kvp.Value)))),
+            });
         }
 
         private string Concat(params string[] values)

--- a/DFC.Composite.Shell.IntegrationTests/Fakes/FakeContentRetriever.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Fakes/FakeContentRetriever.cs
@@ -1,4 +1,5 @@
-﻿using DFC.Composite.Shell.Models.AppRegistrationModels;
+﻿using System;
+using DFC.Composite.Shell.Models.AppRegistrationModels;
 using DFC.Composite.Shell.Services.ContentRetrieval;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +11,8 @@ namespace DFC.Composite.Shell.IntegrationTests.Fakes
 {
     public class FakeContentRetriever : IContentRetriever
     {
+        public const string FileContentType = "application/pdf";
+        public const string FileName = "FileName.pdf";
         public Task<string> GetContent(
             string url,
             string path,
@@ -32,15 +35,25 @@ namespace DFC.Composite.Shell.IntegrationTests.Fakes
             IEnumerable<KeyValuePair<string, string>> formParameters,
             string requestBaseUrl)
         {
-            return Task.FromResult(new PostResponseModel
-            {
-                Html = Concat(
-                    "POST",
-                    url,
-                    path,
-                    regionModel?.PageRegion.ToString(),
-                    string.Join(", ", formParameters.Select(kvp => string.Concat(kvp.Key, "=", kvp.Value)))),
-            });
+            return formParameters.Any(f => f.Key.Equals("download", StringComparison.InvariantCultureIgnoreCase))
+                ? Task.FromResult(new PostResponseModel
+                {
+                    FileDownloadModel = new FileDownloadModel
+                    {
+                        FileContentType = FileContentType,
+                        FileName = FileName,
+                        FileBytes = Array.Empty<byte>(),
+                    },
+                })
+                : Task.FromResult(new PostResponseModel
+                {
+                    Html = Concat(
+                        "POST",
+                        url,
+                        path,
+                        regionModel?.PageRegion.ToString(),
+                        string.Join(", ", formParameters.Select(kvp => string.Concat(kvp.Key, "=", kvp.Value)))),
+                });
         }
 
         private string Concat(params string[] values)

--- a/DFC.Composite.Shell.IntegrationTests/Fakes/FakeContentRetriever.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Fakes/FakeContentRetriever.cs
@@ -34,7 +34,7 @@ namespace DFC.Composite.Shell.IntegrationTests.Fakes
         {
             return Task.FromResult(new PostResponseModel
             {
-                HTML = Concat(
+                Html = Concat(
                     "POST",
                     url,
                     path,

--- a/DFC.Composite.Shell.IntegrationTests/Tests/ApplicationPostTests.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Tests/ApplicationPostTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using DFC.Composite.Shell.IntegrationTests.Fakes;
 using Xunit;
 
 namespace DFC.Composite.Shell.Integration.Test
@@ -38,5 +39,27 @@ namespace DFC.Composite.Shell.Integration.Test
             // Assert
             Assert.Contains(expected, actual, StringComparison.OrdinalIgnoreCase);
         }
+
+        [Fact]
+        public async Task When_ShellSendsPostData_ItsSendItToRegisteredApplicationAndReturnsFileDownload()
+        {
+            // Arrange
+            var shellUri = new Uri("path1/edit?id=1", UriKind.Relative);
+            var client = factory.CreateClientWithWebHostBuilder();
+
+            using var formContent = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("download", "true"),
+            });
+
+            // Act
+            var response = await client.PostAsync(shellUri, formContent);
+            response.EnsureSuccessStatusCode();
+
+            // Assert
+            Assert.Equal(FakeContentRetriever.FileContentType, response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(FakeContentRetriever.FileName, response.Content.Headers.ContentDisposition.FileNameStar);
+        }
+
     }
 }

--- a/DFC.Composite.Shell.Models/FileDownloadModel.cs
+++ b/DFC.Composite.Shell.Models/FileDownloadModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DFC.Composite.Shell.Models
+{
+    public class FileDownloadModel
+    {
+        public string FileName { get; set; }
+        public byte[] FileBytes { get; set; }
+        public string FileContentType { get; set; }
+    }
+}

--- a/DFC.Composite.Shell.Models/PageViewModel.cs
+++ b/DFC.Composite.Shell.Models/PageViewModel.cs
@@ -29,5 +29,9 @@ namespace DFC.Composite.Shell.Models
         public HtmlString PhaseBannerHtml { get; set; }
 
         public List<PageRegionContentModel> PageRegionContentModels { get; set; }
+
+        public bool IsFileDownload => FileDownloadModel != null;
+
+        public FileDownloadModel FileDownloadModel { get; set; }
     }
 }

--- a/DFC.Composite.Shell.Models/PostResponseModel.cs
+++ b/DFC.Composite.Shell.Models/PostResponseModel.cs
@@ -2,7 +2,7 @@
 {
     public class PostResponseModel
     {
-        public string HTML { get; set; }
+        public string Html { get; set; }
         public bool IsFileDownload => FileDownloadModel != null;
         public FileDownloadModel FileDownloadModel { get; set; }
     }

--- a/DFC.Composite.Shell.Models/PostResponseModel.cs
+++ b/DFC.Composite.Shell.Models/PostResponseModel.cs
@@ -1,0 +1,9 @@
+﻿namespace DFC.Composite.Shell.Models
+{
+    public class PostResponseModel
+    {
+        public string HTML { get; set; }
+        public bool IsFileDownload => FileDownloadModel != null;
+        public FileDownloadModel FileDownloadModel { get; set; }
+    }
+}

--- a/DFC.Composite.Shell.Services/Application/ApplicationService.cs
+++ b/DFC.Composite.Shell.Services/Application/ApplicationService.cs
@@ -216,7 +216,7 @@ namespace DFC.Composite.Shell.Services.Application
 
             if (bodyRegion == null || string.IsNullOrWhiteSpace(bodyRegion.RegionEndpoint))
             {
-                return await Task.FromResult(new PostResponseModel());
+                return new PostResponseModel();
             }
 
             var url = FormatArticleUrl(bodyRegion.RegionEndpoint, application.Article, string.Empty);
@@ -298,7 +298,7 @@ namespace DFC.Composite.Shell.Services.Application
                 }
                 else
                 {
-                    outputHtmlMarkup = contentProcessorService.Process(taskResult.HTML, RequestBaseUrl, application.RootUrl);
+                    outputHtmlMarkup = contentProcessorService.Process(taskResult.Html, RequestBaseUrl, application.RootUrl);
                     pageRegionContentModel.Content = new HtmlString(outputHtmlMarkup);
                 }
             }

--- a/DFC.Composite.Shell.Services/ContentRetrieval/ContentRetriever.cs
+++ b/DFC.Composite.Shell.Services/ContentRetrieval/ContentRetriever.cs
@@ -179,14 +179,14 @@ namespace DFC.Composite.Shell.Services.ContentRetrieval
                     }
                     else
                     {
-                        results.HTML = await response.Content.ReadAsStringAsync();
+                        results.Html = await response.Content.ReadAsStringAsync();
                     }
 
                     logger.LogInformation($"{nameof(PostContent)}: Received child response from: {url}");
                 }
                 else
                 {
-                    results.HTML = !string.IsNullOrWhiteSpace(regionModel.OfflineHtml)
+                    results.Html = !string.IsNullOrWhiteSpace(regionModel.OfflineHtml)
                         ? regionModel.OfflineHtml
                         : markupMessages.GetRegionOfflineHtml(regionModel.PageRegion);
                 }
@@ -200,7 +200,7 @@ namespace DFC.Composite.Shell.Services.ContentRetrieval
                     await appRegistryDataService.SetRegionHealthState(path, regionModel.PageRegion, false);
                 }
 
-                results.HTML = !string.IsNullOrWhiteSpace(regionModel.OfflineHtml)
+                results.Html = !string.IsNullOrWhiteSpace(regionModel.OfflineHtml)
                     ? regionModel.OfflineHtml
                     : markupMessages.GetRegionOfflineHtml(regionModel.PageRegion);
             }

--- a/DFC.Composite.Shell.Services/ContentRetrieval/IContentRetriever.cs
+++ b/DFC.Composite.Shell.Services/ContentRetrieval/IContentRetriever.cs
@@ -1,6 +1,7 @@
 ﻿using DFC.Composite.Shell.Models.AppRegistrationModels;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DFC.Composite.Shell.Models;
 using Microsoft.AspNetCore.Http;
 
 namespace DFC.Composite.Shell.Services.ContentRetrieval
@@ -9,6 +10,6 @@ namespace DFC.Composite.Shell.Services.ContentRetrieval
     {
         Task<string> GetContent(string url, string path, RegionModel regionModel, bool followRedirects, string requestBaseUrl, IHeaderDictionary headers);
 
-        Task<string> PostContent(string url, string path, RegionModel regionModel, IEnumerable<KeyValuePair<string, string>> formParameters, string requestBaseUrl);
+        Task<PostResponseModel> PostContent(string url, string path, RegionModel regionModel, IEnumerable<KeyValuePair<string, string>> formParameters, string requestBaseUrl);
     }
 }

--- a/DFC.Composite.Shell.UnitTests/ServicesTests/ApplicationServiceTests.cs
+++ b/DFC.Composite.Shell.UnitTests/ServicesTests/ApplicationServiceTests.cs
@@ -256,8 +256,12 @@ namespace DFC.Composite.Shell.Test.ServicesTests
 
             var pageModel = new PageViewModel();
             await mapper.Map(fakeApplicationModel, pageModel);
+            var postResponse = new PostResponseModel
+            {
+                HTML = BodyRegionContent,
+            };
 
-            A.CallTo(() => contentRetriever.PostContent($"{defaultBodyRegion.RegionEndpoint}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, defaultBodyRegion, defaultFormPostParams, RequestBaseUrl)).Returns(BodyRegionContent);
+            A.CallTo(() => contentRetriever.PostContent($"{defaultBodyRegion.RegionEndpoint}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, defaultBodyRegion, defaultFormPostParams, RequestBaseUrl)).Returns(postResponse);
             A.CallTo(() => contentRetriever.GetContent($"{defaultBodyFooterRegion.RegionEndpoint}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, defaultBodyFooterRegion, A<bool>.Ignored, RequestBaseUrl, A<IHeaderDictionary>.Ignored)).Returns(BodyFooterRegionContent);
 
             // Act
@@ -283,8 +287,12 @@ namespace DFC.Composite.Shell.Test.ServicesTests
             fakeApplicationModel.AppRegistrationModel.Regions = fakeRegions;
             var pageModel = new PageViewModel();
             await mapper.Map(fakeApplicationModel, pageModel);
+            var postResponse = new PostResponseModel
+            {
+                HTML = BodyRegionContent,
+            };
 
-            A.CallTo(() => contentRetriever.PostContent($"{RequestBaseUrl}/{fakeApplicationModel.AppRegistrationModel.Path}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, fakeBodyRegion, defaultFormPostParams, RequestBaseUrl)).Returns(BodyRegionContent);
+            A.CallTo(() => contentRetriever.PostContent($"{RequestBaseUrl}/{fakeApplicationModel.AppRegistrationModel.Path}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, fakeBodyRegion, defaultFormPostParams, RequestBaseUrl)).Returns(postResponse);
             A.CallTo(() => contentRetriever.GetContent($"{defaultBodyFooterRegion.RegionEndpoint}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, defaultBodyFooterRegion, A<bool>.Ignored, RequestBaseUrl, A<IHeaderDictionary>.Ignored)).Returns(BodyFooterRegionContent);
 
             // Act

--- a/DFC.Composite.Shell.UnitTests/ServicesTests/ApplicationServiceTests.cs
+++ b/DFC.Composite.Shell.UnitTests/ServicesTests/ApplicationServiceTests.cs
@@ -277,6 +277,45 @@ namespace DFC.Composite.Shell.Test.ServicesTests
         }
 
         [Fact]
+        public async Task PostMarkupAsyncForOnlineApplicationFileDownload()
+        {
+            // Arrange
+            var footerAndBodyRegions = new List<RegionModel> { defaultHeadRegion, defaultBodyRegion, defaultBodyFooterRegion };
+            var fakeApplicationModel = new ApplicationModel { AppRegistrationModel = defaultAppRegistrationModel, Article = Article };
+            fakeApplicationModel.AppRegistrationModel.Regions = footerAndBodyRegions;
+            var contentType = "application/pdf";
+            var fileName = "FileName.pdf";
+            var pageModel = new PageViewModel();
+            await mapper.Map(fakeApplicationModel, pageModel);
+            var postResponse = new PostResponseModel
+            {
+                FileDownloadModel = new FileDownloadModel
+                {
+                    FileBytes = Array.Empty<byte>(),
+                    FileContentType = contentType,
+                    FileName = fileName,
+                },
+            };
+
+            A.CallTo(() => contentRetriever.PostContent($"{defaultBodyRegion.RegionEndpoint}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, defaultBodyRegion, defaultFormPostParams, RequestBaseUrl)).Returns(postResponse);
+            A.CallTo(() => contentRetriever.GetContent($"{defaultBodyFooterRegion.RegionEndpoint}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, defaultBodyFooterRegion, A<bool>.Ignored, RequestBaseUrl, A<IHeaderDictionary>.Ignored)).Returns(BodyFooterRegionContent);
+
+            // Act
+            await applicationService.PostMarkupAsync(fakeApplicationModel, defaultFormPostParams, pageModel, string.Empty, new HeaderDictionary());
+
+            //Assert
+            Assert.True(pageModel.IsFileDownload);
+            Assert.Equal(contentType, pageModel.FileDownloadModel.FileContentType);
+            Assert.Equal(fileName, pageModel.FileDownloadModel.FileName);
+            Assert.Equal(footerAndBodyRegions.Count, pageModel.PageRegionContentModels.Count);
+            Assert.Equal(BodyFooterRegionContent, pageModel.PageRegionContentModels.First(x => x.PageRegionType == PageRegion.BodyFooter).Content.Value);
+
+            A.CallTo(() => contentRetriever.PostContent($"{defaultBodyRegion.RegionEndpoint}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, defaultBodyRegion, defaultFormPostParams, RequestBaseUrl)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => contentRetriever.GetContent($"{defaultBodyFooterRegion.RegionEndpoint}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, defaultBodyFooterRegion, A<bool>.Ignored, RequestBaseUrl, A<IHeaderDictionary>.Ignored)).MustHaveHappenedOnceExactly();
+        }
+
+
+        [Fact]
         public async Task PostMarkupAsyncForOnlineApplicationWhenBodyRegionEndpointIsEmptyThenContentNotPosted()
         {
             // Arrange

--- a/DFC.Composite.Shell.UnitTests/ServicesTests/ApplicationServiceTests.cs
+++ b/DFC.Composite.Shell.UnitTests/ServicesTests/ApplicationServiceTests.cs
@@ -258,7 +258,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
             await mapper.Map(fakeApplicationModel, pageModel);
             var postResponse = new PostResponseModel
             {
-                HTML = BodyRegionContent,
+                Html = BodyRegionContent,
             };
 
             A.CallTo(() => contentRetriever.PostContent($"{defaultBodyRegion.RegionEndpoint}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, defaultBodyRegion, defaultFormPostParams, RequestBaseUrl)).Returns(postResponse);
@@ -289,7 +289,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
             await mapper.Map(fakeApplicationModel, pageModel);
             var postResponse = new PostResponseModel
             {
-                HTML = BodyRegionContent,
+                Html = BodyRegionContent,
             };
 
             A.CallTo(() => contentRetriever.PostContent($"{RequestBaseUrl}/{fakeApplicationModel.AppRegistrationModel.Path}/{Article}", fakeApplicationModel.AppRegistrationModel.Path, fakeBodyRegion, defaultFormPostParams, RequestBaseUrl)).Returns(postResponse);

--- a/DFC.Composite.Shell.UnitTests/ServicesTests/ContentRetrieverTests.cs
+++ b/DFC.Composite.Shell.UnitTests/ServicesTests/ContentRetrieverTests.cs
@@ -421,7 +421,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
 
             var result = await service.PostContent("http://someUrl", "path", model, defaultFormPostParams, "http://baseUrl");
 
-            Assert.Equal(DummyChildAppContent, result.HTML);
+            Assert.Equal(DummyChildAppContent, result.Html);
 
             httpResponseMessage.Dispose();
             fakeRedirectHttpMessageHandler.Dispose();
@@ -440,7 +440,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
 
             var result = await defaultService.PostContent("http://someUrl", "path", model, defaultFormPostParams, "http://baseUrl");
 
-            Assert.Equal(OfflineHtml, result.HTML);
+            Assert.Equal(OfflineHtml, result.Html);
         }
 
         [Fact]
@@ -455,7 +455,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
 
             var result = await defaultService.PostContent("http://someUrl", "path", model, defaultFormPostParams, "http://baseUrl");
 
-            Assert.Equal(markupMessages.RegionOfflineHtml[model.PageRegion], result.HTML);
+            Assert.Equal(markupMessages.RegionOfflineHtml[model.PageRegion], result.Html);
         }
 
         [Fact(Skip = "Needs revisiting as part of DFC-11808")]
@@ -508,7 +508,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
             A.CallTo(() => fakeRegionService.SetRegionHealthState(A<string>.Ignored, A<PageRegion>.Ignored, false))
                 .MustNotHaveHappened();
 
-            Assert.Equal(OfflineHtml, result.HTML);
+            Assert.Equal(OfflineHtml, result.Html);
         }
 
         [Fact]

--- a/DFC.Composite.Shell.UnitTests/ServicesTests/ContentRetrieverTests.cs
+++ b/DFC.Composite.Shell.UnitTests/ServicesTests/ContentRetrieverTests.cs
@@ -421,7 +421,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
 
             var result = await service.PostContent("http://someUrl", "path", model, defaultFormPostParams, "http://baseUrl");
 
-            Assert.Equal(DummyChildAppContent, result);
+            Assert.Equal(DummyChildAppContent, result.HTML);
 
             httpResponseMessage.Dispose();
             fakeRedirectHttpMessageHandler.Dispose();
@@ -440,7 +440,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
 
             var result = await defaultService.PostContent("http://someUrl", "path", model, defaultFormPostParams, "http://baseUrl");
 
-            Assert.Equal(OfflineHtml, result);
+            Assert.Equal(OfflineHtml, result.HTML);
         }
 
         [Fact]
@@ -455,7 +455,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
 
             var result = await defaultService.PostContent("http://someUrl", "path", model, defaultFormPostParams, "http://baseUrl");
 
-            Assert.Equal(markupMessages.RegionOfflineHtml[model.PageRegion], result);
+            Assert.Equal(markupMessages.RegionOfflineHtml[model.PageRegion], result.HTML);
         }
 
         [Fact(Skip = "Needs revisiting as part of DFC-11808")]
@@ -508,7 +508,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
             A.CallTo(() => fakeRegionService.SetRegionHealthState(A<string>.Ignored, A<PageRegion>.Ignored, false))
                 .MustNotHaveHappened();
 
-            Assert.Equal(OfflineHtml, result);
+            Assert.Equal(OfflineHtml, result.HTML);
         }
 
         [Fact]

--- a/DFC.Composite.Shell/Controllers/ApplicationController.cs
+++ b/DFC.Composite.Shell/Controllers/ApplicationController.cs
@@ -204,6 +204,11 @@ namespace DFC.Composite.Shell.Controllers
                             {
                                 postFirstRequest = false;
                                 await applicationService.PostMarkupAsync(application, formParameters, viewModel, string.Empty, Request.Headers);
+                                if (viewModel.IsFileDownload)
+                                {
+                                    var fileDetails = viewModel.FileDownloadModel;
+                                    return File(fileDetails.FileBytes, fileDetails.FileContentType, fileDetails.FileName);
+                                }
                             }
                             else
                             {

--- a/DFC.Composite.Shell/Extensions/ServiceCollectionExtensions.cs
+++ b/DFC.Composite.Shell/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,8 @@ namespace DFC.Composite.Shell.Extensions
                 retryPolicyKey,
                 HttpPolicyExtensions
                     .HandleTransientHttpError()
-                    .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+                    .OrResult(msg => 
+                        msg.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
                     .OrResult(msg => msg?.Headers?.RetryAfter != null)
                     .WaitAndRetryAsync(
                         policyOptions.HttpRetry.Count,


### PR DESCRIPTION
File download support is specific to POST requests only and only PDF and Word DOCX file types at this time.
This is to support functionality required in the Skills Health Check app.