### PR TITLE
Adding gstatic into CSP source

### DIFF
--- a/DFC.Composite.Shell/Startup.cs
+++ b/DFC.Composite.Shell/Startup.cs
@@ -97,6 +97,7 @@ namespace DFC.Composite.Shell
                         webchatCspDomain + "/js/",
                         $"{Configuration.GetValue<string>(Constants.ApplicationInsightsScriptResourceAddress)}",
                         "https://www.youtube.com",
+                        "https://www.gstatic.com",
                         "https://www.google-analytics.com",
                         "https://optimize.google.com",
                         "https://www.googleoptimize.com",
@@ -127,6 +128,7 @@ namespace DFC.Composite.Shell
                         "www.google-analytics.com",
                         "*.doubleclick.net",
                         "https://i.ytimg.com",
+                        "https://www.gstatic.com",
                         "https://optimize.google.com",
                         "https://www.googleoptimize.com",
                         "https://www.googletagmanager.com"))

--- a/DFC.Composite.Shell/Views/Shared/_GoogleTagManagerScripts.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_GoogleTagManagerScripts.cshtml
@@ -1,4 +1,7 @@
 ﻿@model PageViewModelResponse;
+
+<!-- Google Optimize snippet (Hard coded container ID)>
+<script nws-csp-add-nonce="true" async src="https://www.googleoptimize.com/optimize.js?id=OPT-PMJP8V3"></script>
 <!-- Page-hiding snippet (recommended)  -->
 <script nws-csp-add-nonce="true">
     (function (a, s, y, n, c, h, i, d, e) {

--- a/DFC.Composite.Shell/Views/Shared/_GoogleTagManagerScripts.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_GoogleTagManagerScripts.cshtml
@@ -1,6 +1,6 @@
 ﻿@model PageViewModelResponse;
 
-<!-- Google Optimize snippet (Hard coded container ID)>
+<!-- Google Optimize snippet (Hard coded container ID)-->
 <script nws-csp-add-nonce="true" async src="https://www.googleoptimize.com/optimize.js?id=OPT-PMJP8V3"></script>
 <!-- Page-hiding snippet (recommended)  -->
 <script nws-csp-add-nonce="true">


### PR DESCRIPTION
adding https://www.gstatic.com into CSP source. This is the site for static google content, used in google services like optimize editor.