### PR TITLE
[AD-182473] Temporary fix for King Charles III Tudor Crown

### DIFF
--- a/DFC.Composite.Shell/Views/Error/Error.cshtml
+++ b/DFC.Composite.Shell/Views/Error/Error.cshtml
@@ -11,13 +11,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <partial name="_GoogleTagManagerScripts" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta property="og:image" content="@(BrandingAssetsFolder)/images/govuk-opengraph-image.png">
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="@(BrandingAssetsFolder)/images/favicon.ico" type="image/x-icon" />
-    <link rel="mask-icon" href="@(BrandingAssetsFolder)/images/govuk-mask-icon.svg" color="blue">
-    <link rel="apple-touch-icon" sizes="180x180" href="@(BrandingAssetsFolder)/images/govuk-apple-touch-icon-180x180.png">
-    <link rel="apple-touch-icon" sizes="167x167" href="@(BrandingAssetsFolder)/images/govuk-apple-touch-icon-167x167.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="@(BrandingAssetsFolder)/images/govuk-apple-touch-icon-152x152.png">
-    <link rel="apple-touch-icon" href="@(BrandingAssetsFolder)/images/govuk-apple-touch-icon.png">
+    <meta property="og:image" content="@(BrandingAssetsFolder)/images/govuk-opengraph-crown-image.png">
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="@(BrandingAssetsFolder)/images/favicon-crown.ico" type="image/x-icon" />
+    <link rel="mask-icon" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-mask.svg" color="blue">
+    <link rel="icon" sizes="180x180" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-180.png">
+    <link rel="icon" sizes="192x192" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-192.png">
+    <link rel="icon" sizes="512x512" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-512.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-180.png">
     <link href="@(BrandingAssetsFolder)/css/all.min.css" rel="stylesheet" type="text/css" />
     <title>@Model.PageTitle</title>
 </head>

--- a/DFC.Composite.Shell/Views/Error/Error.cshtml
+++ b/DFC.Composite.Shell/Views/Error/Error.cshtml
@@ -11,13 +11,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <partial name="_GoogleTagManagerScripts" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta property="og:image" content="@(BrandingAssetsFolder)/images/govuk-opengraph-crown-image.png">
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="@(BrandingAssetsFolder)/images/favicon-crown.ico" type="image/x-icon" />
-    <link rel="mask-icon" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-mask.svg" color="blue">
-    <link rel="icon" sizes="180x180" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-180.png">
-    <link rel="icon" sizes="192x192" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-192.png">
-    <link rel="icon" sizes="512x512" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-512.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-180.png">
+    <meta property="og:image" content="@(BrandingAssetsFolder)/images/govuk-opengraph-image-tudor-crown.png">
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="@(BrandingAssetsFolder)/images/govuk-favicon-tudor-crown.ico" type="image/x-icon" />
+    <link rel="mask-icon" href="@(BrandingAssetsFolder)/images/govuk-icon-mask-tudor-crown.svg" color="#0b0c0c">
+    <link rel="apple-touch-icon" href="@(BrandingAssetsFolder)/images/govuk-icon-180-tudor-crown.png">
     <link href="@(BrandingAssetsFolder)/css/all.min.css" rel="stylesheet" type="text/css" />
     <title>@Model.PageTitle</title>
 </head>

--- a/DFC.Composite.Shell/Views/Shared/_Head.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_Head.cshtml
@@ -19,14 +19,13 @@
 <partial name="_GoogleTagManagerScripts" />
 <partial name="_MicrosoftClarityScript" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-<meta property="og:image" content="@(BrandingAssetsFolder)/images/govuk-opengraph-image.png">
-
-<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="@(BrandingAssetsFolder)/images/favicon.ico" type="image/x-icon" />
-<link rel="mask-icon" href="@(BrandingAssetsFolder)/images/govuk-mask-icon.svg" color="blue">
-<link rel="apple-touch-icon" sizes="180x180" href="@(BrandingAssetsFolder)/images/govuk-apple-touch-icon-180x180.png">
-<link rel="apple-touch-icon" sizes="167x167" href="@(BrandingAssetsFolder)/images/govuk-apple-touch-icon-167x167.png">
-<link rel="apple-touch-icon" sizes="152x152" href="@(BrandingAssetsFolder)/images/govuk-apple-touch-icon-152x152.png">
-<link rel="apple-touch-icon" href="@(BrandingAssetsFolder)/images/govuk-apple-touch-icon.png">
+<meta property="og:image" content="@(BrandingAssetsFolder)/images/govuk-opengraph-crown-image.png">
+<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="@(BrandingAssetsFolder)/images/favicon-crown.ico" type="image/x-icon" />
+<link rel="mask-icon" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-mask.svg" color="blue">
+<link rel="icon" sizes="180x180" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-180.png">
+<link rel="icon" sizes="192x192" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-192.png">
+<link rel="icon" sizes="512x512" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-512.png">
+<link rel="apple-touch-icon" sizes="180x180" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-180.png">
 
 @{
     var versionedPathForCssScripts = ViewData["VersionedPathForCssScripts"] as List<string>;

--- a/DFC.Composite.Shell/Views/Shared/_Head.cshtml
+++ b/DFC.Composite.Shell/Views/Shared/_Head.cshtml
@@ -19,13 +19,11 @@
 <partial name="_GoogleTagManagerScripts" />
 <partial name="_MicrosoftClarityScript" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-<meta property="og:image" content="@(BrandingAssetsFolder)/images/govuk-opengraph-crown-image.png">
-<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="@(BrandingAssetsFolder)/images/favicon-crown.ico" type="image/x-icon" />
-<link rel="mask-icon" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-mask.svg" color="blue">
-<link rel="icon" sizes="180x180" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-180.png">
-<link rel="icon" sizes="192x192" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-192.png">
-<link rel="icon" sizes="512x512" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-512.png">
-<link rel="apple-touch-icon" sizes="180x180" href="@(BrandingAssetsFolder)/images/govuk-crown-icon-180.png">
+<meta property="og:image" content="@(BrandingAssetsFolder)/images/govuk-opengraph-image-tudor-crown.png">
+
+<link rel="shortcut icon" sizes="16x16 32x32 48x48" href="@(BrandingAssetsFolder)/images/govuk-favicon-tudor-crown.ico" type="image/x-icon" />
+<link rel="mask-icon" href="@(BrandingAssetsFolder)/images/govuk-icon-mask-tudor-crown.svg" color="#0b0c0c">
+<link rel="apple-touch-icon" href="@(BrandingAssetsFolder)/images/govuk-icon-180-tudor-crown.png">
 
 @{
     var versionedPathForCssScripts = ViewData["VersionedPathForCssScripts"] as List<string>;


### PR DESCRIPTION
**AD Link**: https://sfa-gov-uk.visualstudio.com/National%20Careers%20Service%20(NCS)/_workitems/edit/182473

**Description**: a temporary workaround fix to correct the formal crown used on GOV.UK web pages. New assets added in https://github.com/SkillsFundingAgency/dfc-digital-assets/pull/866 are now referenced in the views. Usually these files are populated at build from the `govuk-frontend` package (via the CDN), however due to the package being out of date, we must temporarily add new assets and reference.

**Good to know**: This change will be reverted/amended once the `govuk-frontend` package has been upgraded to the latest version (as this version will contain the correct assets by default)

**Associated PRs**
- https://github.com/SkillsFundingAgency/dfc-digital-assets/pull/866