### PR TITLE
[AD-189281] Robots.txt fixes (post ASE migration)

### DIFF
--- a/DFC.Composite.Shell.IntegrationTests/Tests/RobotsTests.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Tests/RobotsTests.cs
@@ -28,6 +28,7 @@ namespace DFC.Composite.Shell.Integration.Test
             Assert.Equal(MediaTypeNames.Text.Plain, response.Content.Headers.ContentType.MediaType);
             Assert.Equal(
 @"User-agent: *
+Disallow: /webchat/
 Disallow: /", responseHtml);
         }
 
@@ -43,13 +44,8 @@ Disallow: /", responseHtml);
 
             Assert.Equal(MediaTypeNames.Text.Plain, response.Content.Headers.ContentType.MediaType);
             Assert.Equal(
-@"User-agent: SemrushBot-SA
-Disallow: /alerts/
-Disallow: /ab/
+@"User-agent: *
 Disallow: /webchat/
-Sitemap: https://dfc-pp-compui-shell-as-ver2.azurewebsites.net/sitemap.xml
-
-User-agent: *
 Disallow: /", responseHtml);
         }
 

--- a/DFC.Composite.Shell.IntegrationTests/Tests/RobotsTests.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Tests/RobotsTests.cs
@@ -28,7 +28,6 @@ namespace DFC.Composite.Shell.Integration.Test
             Assert.Equal(MediaTypeNames.Text.Plain, response.Content.Headers.ContentType.MediaType);
             Assert.Equal(
 @"User-agent: *
-Disallow: /webchat/
 Disallow: /", responseHtml);
         }
 
@@ -45,7 +44,6 @@ Disallow: /", responseHtml);
             Assert.Equal(MediaTypeNames.Text.Plain, response.Content.Headers.ContentType.MediaType);
             Assert.Equal(
 @"User-agent: *
-Disallow: /webchat/
 Disallow: /", responseHtml);
         }
 

--- a/DFC.Composite.Shell.IntegrationTests/Tests/RobotsTests.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Tests/RobotsTests.cs
@@ -36,7 +36,7 @@ Disallow: /", responseHtml);
         {
             var client = factory.CreateClientWithWebHostBuilder();
 
-            var response = await client.GetAsync(new Uri("https://dfc-pp-compui-shell-as.ase-01.dfc.preprodazure.sfa.bis.gov.uk/robots.txt", UriKind.Absolute));
+            var response = await client.GetAsync(new Uri("https://dfc-pp-compui-shell-as-ver2.azurewebsites.net/robots.txt", UriKind.Absolute));
 
             response.EnsureSuccessStatusCode();
             var responseHtml = await response.Content.ReadAsStringAsync();
@@ -47,7 +47,7 @@ Disallow: /", responseHtml);
 Disallow: /alerts/
 Disallow: /ab/
 Disallow: /webchat/
-Sitemap: https://dfc-pp-compui-shell-as.ase-01.dfc.preprodazure.sfa.bis.gov.uk/sitemap.xml
+Sitemap: https://dfc-pp-compui-shell-as-ver2.azurewebsites.net/sitemap.xml
 
 User-agent: *
 Disallow: /", responseHtml);
@@ -58,7 +58,7 @@ Disallow: /", responseHtml);
         {
             var client = factory.CreateClientWithWebHostBuilder();
 
-            var response = await client.GetAsync(new Uri("https://dfc-prd-compui-shell-as.ase-01.dfc.prodazure.sfa.bis.gov.uk/robots.txt", UriKind.Absolute));
+            var response = await client.GetAsync(new Uri("https://dfc-prd-compui-shell-as-ver2.azurewebsites.net/robots.txt", UriKind.Absolute));
 
             response.EnsureSuccessStatusCode();
             var responseHtml = await response.Content.ReadAsStringAsync();
@@ -73,7 +73,7 @@ Disallow: /find-a-course/details*
 Disallow: /find-a-course/course-details*
 Disallow: /find-a-course/tdetails*
 Disallow: /find-a-course/tlevels*
-Sitemap: https://dfc-prd-compui-shell-as.ase-01.dfc.prodazure.sfa.bis.gov.uk/sitemap.xml", responseHtml);
+Sitemap: https://dfc-prd-compui-shell-as-ver2.azurewebsites.net/sitemap.xml", responseHtml);
         }
     }
 }

--- a/DFC.Composite.Shell.IntegrationTests/Tests/ShellRobotFileServiceTests.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Tests/ShellRobotFileServiceTests.cs
@@ -16,6 +16,7 @@ namespace DFC.Composite.Shell.IntegrationTests.Tests
         {
             const string expectedFileText =
 @"User-agent: *
+Disallow: /webchat/
 Disallow: /";
 
             var fileInfoHelper = new FileInfoHelper();
@@ -34,6 +35,7 @@ Disallow: /";
         {
             const string expectedFileText =
 @"User-agent: *
+Disallow: /webchat/
 Disallow: /";
 
             var fileInfoHelper = new FileInfoHelper();

--- a/DFC.Composite.Shell.IntegrationTests/Tests/ShellRobotFileServiceTests.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Tests/ShellRobotFileServiceTests.cs
@@ -33,13 +33,7 @@ Disallow: /";
         public async Task GetFileTextIdentifiesCorrectResponseForPreProd()
         {
             const string expectedFileText =
-@"User-agent: SemrushBot-SA
-Disallow: /alerts/
-Disallow: /ab/
-Disallow: /webchat/
-{Insertion}
-
-User-agent: *
+@"User-agent: *
 Disallow: /";
 
             var fileInfoHelper = new FileInfoHelper();

--- a/DFC.Composite.Shell.IntegrationTests/Tests/ShellRobotFileServiceTests.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Tests/ShellRobotFileServiceTests.cs
@@ -16,7 +16,6 @@ namespace DFC.Composite.Shell.IntegrationTests.Tests
         {
             const string expectedFileText =
 @"User-agent: *
-Disallow: /webchat/
 Disallow: /";
 
             var fileInfoHelper = new FileInfoHelper();
@@ -35,7 +34,6 @@ Disallow: /";
         {
             const string expectedFileText =
 @"User-agent: *
-Disallow: /webchat/
 Disallow: /";
 
             var fileInfoHelper = new FileInfoHelper();

--- a/DFC.Composite.Shell.IntegrationTests/Tests/ShellRobotFileServiceTests.cs
+++ b/DFC.Composite.Shell.IntegrationTests/Tests/ShellRobotFileServiceTests.cs
@@ -45,7 +45,7 @@ Disallow: /";
             var fileInfoHelper = new FileInfoHelper();
 
             var httpContextAccessor = A.Fake<IHttpContextAccessor>();
-            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-pp-compui-shell-as.ase-01.dfc.preprodazure.sfa.bis.gov.uk"));
+            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-pp-compui-shell-as-ver2.azurewebsites.net"));
 
             var service = new ShellRobotFileService(fileInfoHelper, httpContextAccessor);
 
@@ -70,7 +70,7 @@ Disallow: /find-a-course/tlevels*
             var fileInfoHelper = new FileInfoHelper();
 
             var httpContextAccessor = A.Fake<IHttpContextAccessor>();
-            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-prd-compui-shell-as.ase-01.dfc.prodazure.sfa.bis.gov.uk"));
+            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-prd-compui-shell-as-ver2.azurewebsites.net"));
 
             var service = new ShellRobotFileService(fileInfoHelper, httpContextAccessor);
 

--- a/DFC.Composite.Shell.Services/ShellRobotFile/ShellRobotFileService.cs
+++ b/DFC.Composite.Shell.Services/ShellRobotFile/ShellRobotFileService.cs
@@ -6,6 +6,9 @@ namespace DFC.Composite.Shell.Services.ShellRobotFile
 {
     public class ShellRobotFileService : IShellRobotFileService
     {
+        private const string ProductionEnvHostname = "dfc-prd-compui-shell-as-ver2.azurewebsites.net";
+        private const string ProductionEnvRobotFilename = "ProductionStaticRobots.txt";
+        private const string NonProductionEnvRobotFilename = "StaticRobots.txt";
         private readonly IFileInfoHelper fileInfoHelper;
         private readonly IHttpContextAccessor httpContextAccessor;
 
@@ -27,47 +30,17 @@ namespace DFC.Composite.Shell.Services.ShellRobotFile
             return !string.IsNullOrWhiteSpace(shellRobotsText) ? shellRobotsText : string.Empty;
         }
 
-        private static bool IsDraft(string hostname)
-        {
-            const string draft = "draft";
-            return hostname.Contains(draft, System.StringComparison.InvariantCultureIgnoreCase);
-        }
-
-        private static bool IsPreProduction(string hostname)
-        {
-            const string stagingHostname = "dfc-pp-compui-shell-as-ver2.azurewebsites.net";
-            return hostname.Equals(stagingHostname, System.StringComparison.InvariantCultureIgnoreCase);
-        }
-
-        private static bool IsProduction(string hostname)
-        {
-            const string productionHostname = "dfc-prd-compui-shell-as-ver2.azurewebsites.net";
-            return hostname.Equals(productionHostname, System.StringComparison.InvariantCultureIgnoreCase);
-        }
-
         private string StaticRobotsFilename()
         {
-            const string standardRobotsFilename = "StaticRobots.txt";
-            var hostname = httpContextAccessor?.HttpContext?.Request?.Host.Host ?? string.Empty;
+            string hostname = httpContextAccessor?.HttpContext?.Request?.Host.Host ?? string.Empty;
+            bool environmentIsProduction = hostname.Equals(ProductionEnvHostname, System.StringComparison.InvariantCultureIgnoreCase);
 
-            if (IsDraft(hostname))
+            if (environmentIsProduction)
             {
-                return standardRobotsFilename;
+                return ProductionEnvRobotFilename;
             }
 
-            if (IsPreProduction(hostname))
-            {
-                const string stagingRobotsFilename = "StagingStaticRobots.txt";
-                return stagingRobotsFilename;
-            }
-
-            if (IsProduction(hostname))
-            {
-                const string productionRobotsFilename = "ProductionStaticRobots.txt";
-                return productionRobotsFilename;
-            }
-
-            return standardRobotsFilename;
+            return NonProductionEnvRobotFilename;
         }
     }
 }

--- a/DFC.Composite.Shell.Services/ShellRobotFile/ShellRobotFileService.cs
+++ b/DFC.Composite.Shell.Services/ShellRobotFile/ShellRobotFileService.cs
@@ -35,13 +35,13 @@ namespace DFC.Composite.Shell.Services.ShellRobotFile
 
         private static bool IsPreProduction(string hostname)
         {
-            const string stagingHostname = "dfc-pp-compui-shell-as.ase-01.dfc.preprodazure.sfa.bis.gov.uk";
+            const string stagingHostname = "dfc-pp-compui-shell-as-ver2.azurewebsites.net";
             return hostname.Equals(stagingHostname, System.StringComparison.InvariantCultureIgnoreCase);
         }
 
         private static bool IsProduction(string hostname)
         {
-            const string productionHostname = "dfc-prd-compui-shell-as.ase-01.dfc.prodazure.sfa.bis.gov.uk";
+            const string productionHostname = "dfc-prd-compui-shell-as-ver2.azurewebsites.net";
             return hostname.Equals(productionHostname, System.StringComparison.InvariantCultureIgnoreCase);
         }
 

--- a/DFC.Composite.Shell.UnitTests/ServicesTests/ShellRobotFileServiceTests.cs
+++ b/DFC.Composite.Shell.UnitTests/ServicesTests/ShellRobotFileServiceTests.cs
@@ -105,7 +105,6 @@ namespace DFC.Composite.Shell.Test.ServicesTests
         {
             const string expectedFileText =
 @"User-agent: *
-Disallow: /webchat/
 Disallow: /";
 
             var fileInfoHelper = new FileInfoHelper();
@@ -124,7 +123,6 @@ Disallow: /";
         {
             const string expectedFileText =
 @"User-agent: *
-Disallow: /webchat/
 Disallow: /";
 
             var fileInfoHelper = new FileInfoHelper();

--- a/DFC.Composite.Shell.UnitTests/ServicesTests/ShellRobotFileServiceTests.cs
+++ b/DFC.Composite.Shell.UnitTests/ServicesTests/ShellRobotFileServiceTests.cs
@@ -72,7 +72,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
             const string fakeRobotFileText = "StaticRobotsFileText";
             var fileInfoHelper = A.Fake<IFileInfoHelper>();
             A.CallTo(() => fileInfoHelper.FileExists(A<string>.Ignored)).Returns(true);
-            A.CallTo(() => fileInfoHelper.ReadAllTextAsync("SomeRobotsPath\\StagingStaticRobots.txt")).Returns(fakeRobotFileText);
+            A.CallTo(() => fileInfoHelper.ReadAllTextAsync("SomeRobotsPath\\StaticRobots.txt")).Returns(fakeRobotFileText);
 
             var httpContextAccessor = A.Fake<IHttpContextAccessor>();
             A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-pp-compui-shell-as-ver2.azurewebsites.net"));

--- a/DFC.Composite.Shell.UnitTests/ServicesTests/ShellRobotFileServiceTests.cs
+++ b/DFC.Composite.Shell.UnitTests/ServicesTests/ShellRobotFileServiceTests.cs
@@ -75,7 +75,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
             A.CallTo(() => fileInfoHelper.ReadAllTextAsync("SomeRobotsPath\\StagingStaticRobots.txt")).Returns(fakeRobotFileText);
 
             var httpContextAccessor = A.Fake<IHttpContextAccessor>();
-            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-pp-compui-shell-as.ase-01.dfc.preprodazure.sfa.bis.gov.uk"));
+            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-pp-compui-shell-as-ver2.azurewebsites.net"));
 
             var service = new ShellRobotFileService(fileInfoHelper, httpContextAccessor);
 
@@ -92,7 +92,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
             A.CallTo(() => fileInfoHelper.ReadAllTextAsync("SomeRobotsPath\\ProductionStaticRobots.txt")).Returns(fakeRobotFileText);
 
             var httpContextAccessor = A.Fake<IHttpContextAccessor>();
-            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-prd-compui-shell-as.ase-01.dfc.prodazure.sfa.bis.gov.uk"));
+            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-prd-compui-shell-as-ver2.azurewebsites.net"));
 
             var service = new ShellRobotFileService(fileInfoHelper, httpContextAccessor);
 
@@ -134,7 +134,7 @@ Disallow: /";
             var fileInfoHelper = new FileInfoHelper();
 
             var httpContextAccessor = A.Fake<IHttpContextAccessor>();
-            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-pp-compui-shell-as.ase-01.dfc.preprodazure.sfa.bis.gov.uk"));
+            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-pp-compui-shell-as-ver2.azurewebsites.net"));
 
             var service = new ShellRobotFileService(fileInfoHelper, httpContextAccessor);
 
@@ -159,7 +159,7 @@ Disallow: /find-a-course/tlevels*
             var fileInfoHelper = new FileInfoHelper();
 
             var httpContextAccessor = A.Fake<IHttpContextAccessor>();
-            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-prd-compui-shell-as.ase-01.dfc.prodazure.sfa.bis.gov.uk"));
+            A.CallTo(() => httpContextAccessor.HttpContext.Request.Host).Returns(new HostString("dfc-prd-compui-shell-as-ver2.azurewebsites.net"));
 
             var service = new ShellRobotFileService(fileInfoHelper, httpContextAccessor);
 

--- a/DFC.Composite.Shell.UnitTests/ServicesTests/ShellRobotFileServiceTests.cs
+++ b/DFC.Composite.Shell.UnitTests/ServicesTests/ShellRobotFileServiceTests.cs
@@ -105,6 +105,7 @@ namespace DFC.Composite.Shell.Test.ServicesTests
         {
             const string expectedFileText =
 @"User-agent: *
+Disallow: /webchat/
 Disallow: /";
 
             var fileInfoHelper = new FileInfoHelper();
@@ -122,13 +123,8 @@ Disallow: /";
         public async Task GetFileTextIdentifiesCorrectResponseForPreProdIntegration()
         {
             const string expectedFileText =
-@"User-agent: SemrushBot-SA
-Disallow: /alerts/
-Disallow: /ab/
+@"User-agent: *
 Disallow: /webchat/
-{Insertion}
-
-User-agent: *
 Disallow: /";
 
             var fileInfoHelper = new FileInfoHelper();

--- a/DFC.Composite.Shell/DFC.Composite.Shell.csproj
+++ b/DFC.Composite.Shell/DFC.Composite.Shell.csproj
@@ -67,9 +67,6 @@
     <Content Update="wwwroot\ProductionStaticRobots.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Update="wwwroot\StagingStaticRobots.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Update="wwwroot\StaticRobots.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/DFC.Composite.Shell/wwwroot/StagingStaticRobots.txt
+++ b/DFC.Composite.Shell/wwwroot/StagingStaticRobots.txt
@@ -1,8 +1,0 @@
-﻿User-agent: SemrushBot-SA
-Disallow: /alerts/
-Disallow: /ab/
-Disallow: /webchat/
-{Insertion}
-
-User-agent: *
-Disallow: /

--- a/DFC.Composite.Shell/wwwroot/StaticRobots.txt
+++ b/DFC.Composite.Shell/wwwroot/StaticRobots.txt
@@ -1,2 +1,3 @@
 ﻿User-agent: *
+Disallow: /webchat/
 Disallow: /

--- a/DFC.Composite.Shell/wwwroot/StaticRobots.txt
+++ b/DFC.Composite.Shell/wwwroot/StaticRobots.txt
@@ -1,3 +1,2 @@
 ﻿User-agent: *
-Disallow: /webchat/
 Disallow: /


### PR DESCRIPTION
Changes:
- References to old infrastructure have been replaced with their post-ASE migration equivalent

| Old | New |
| --- | --- |
| `https://dfc-pp-compui-shell-as.ase-01.dfc.preprodazure.sfa.bis.gov.uk` | `https://dfc-pp-compui-shell-as-ver2.azurewebsites.net` |
| `https://dfc-prd-compui-shell-as.ase-01.dfc.prodazure.sfa.bis.gov.uk` | `https://dfc-prd-compui-shell-as-ver2.azurewebsites.net` |

- Lionel has confirmed that all lower environments, including PP, should use the same blocking-index file content - refactoring to achieve this outcome
- Unit tests updated to reflect