### PR TITLE
[AD-201498] Action Plan Retirement

### DIFF
--- a/DFC.Composite.Shell.Services/Auth/Models/ActionPlanRetirement.cs
+++ b/DFC.Composite.Shell.Services/Auth/Models/ActionPlanRetirement.cs
@@ -1,0 +1,7 @@
+﻿namespace DFC.Composite.Shell.Services.Auth.Models
+{
+    public class ActionPlanRetirement
+    {
+        public bool AuthFunctionalityRetired { get; set; }
+    }
+}

--- a/DFC.Composite.Shell.UnitTests/Controllers/AuthcontrollerTests.cs
+++ b/DFC.Composite.Shell.UnitTests/Controllers/AuthcontrollerTests.cs
@@ -98,6 +98,8 @@ namespace DFC.Composite.Shell.UnitTests.Controllers
                 Exponent = "AQAB",
             });
 
+            this.defaultConfiguration["ActionPlanRetirement:AuthFunctionalityRetired"] = "false";
+
             tokenHandler = A.Fake<SecurityTokenHandler>();
             configurationManager = A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
             A.CallTo(() => configurationManager.GetConfigurationAsync(CancellationToken.None)).Returns(

--- a/DFC.Composite.Shell/Controllers/AuthController.cs
+++ b/DFC.Composite.Shell/Controllers/AuthController.cs
@@ -52,6 +52,9 @@ namespace DFC.Composite.Shell.Controllers
 
         public async Task<IActionResult> SignIn(string redirectUrl)
         {
+            if (IsAuthRetired())
+                return Redirect("~/");
+
             SetRedirectUrl(GetRedirectURl(redirectUrl));
             var signInUrl = await authClient.GetSignInUrl();
             return Redirect(signInUrl);
@@ -59,12 +62,18 @@ namespace DFC.Composite.Shell.Controllers
 
         public async Task<IActionResult> ResetPassword()
         {
+            if (IsAuthRetired())
+                return Redirect("~/");
+
             var signInUrl = await authClient.GetResetPasswordUrl();
             return Redirect(signInUrl);
         }
 
         public async Task<IActionResult> SignOut(string redirectUrl)
         {
+            if (IsAuthRetired())
+                return Redirect("~/");
+
             var Url = GenerateSignOutUrl(redirectUrl);
             var signInUrl = await authClient.GetSignOutUrl(Url);
             await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
@@ -73,6 +82,9 @@ namespace DFC.Composite.Shell.Controllers
 
         public async Task<IActionResult> Auth(string id_token)
         {
+            if (IsAuthRetired())
+                return Redirect("~/");
+
             JwtSecurityToken validatedToken;
             try
             {
@@ -178,6 +190,11 @@ namespace DFC.Composite.Shell.Controllers
         {
             Uri result;
             return Uri.TryCreate(url, UriKind.Absolute, out result);
+        }
+
+        private bool IsAuthRetired()
+        {
+            return bool.Parse(configuration["ActionPlanRetirement:AuthFunctionalityRetired"]);
         }
     }
 }

--- a/DFC.Composite.Shell/Startup.cs
+++ b/DFC.Composite.Shell/Startup.cs
@@ -239,6 +239,7 @@ namespace DFC.Composite.Shell
             services.Configure<AuthSettings>(Configuration.GetSection(nameof(AuthSettings)));
             services.Configure<GoogleSettings>(Configuration.GetSection("GoogleScripts"));
             services.Configure<MicrosoftSettings>(Configuration.GetSection("MicrosoftScripts"));
+            services.Configure<ActionPlanRetirement>(Configuration.GetSection(nameof(ActionPlanRetirement)));
 
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie(options =>
             {

--- a/Resources/ArmTemplates/template.json
+++ b/Resources/ArmTemplates/template.json
@@ -527,6 +527,10 @@
                         {
                           "name": "MicrosoftScripts__ClarityId",
                           "value": "[parameters('ClarityId')]"
+                        },
+						            {
+                          "name": "ActionPlanRetirement__AuthFunctionalityRetired",
+                          "value": false
                         }
                       ]
                     }


### PR DESCRIPTION
ADO ticket: https://sfa-gov-uk.visualstudio.com/National%20Careers%20Service%20(NCS)/_workitems/edit/201498

**Associated PR**
https://github.com/SkillsFundingAgency/dfc-app-actionplans/pull/159

**File changes**
| File name(s) | Change made |
| -- | -- |
| `ActionPlanRetirement.cs` , `template.json` , `Startup.cs` | Adding new environment variable |
| `AuthControllerTests.cs` | Fixing broken unit tests |
| `AuthController.cs` | Utilising value of new environment variable - if enabled, `/auth/SignIn` , `/auth/ResetPassword` , `/auth/SignOut` and `/auth/auth` routes will redirect to `/` instead |